### PR TITLE
[FE] Header 컴포넌트 반응형 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "react-dom": "^18.2.0",
         "react-pdf": "^7.7.0",
         "react-router-dom": "^6.19.0",
-        "review-me-design-system": "^0.0.5",
+        "review-me-design-system": "^0.0.6",
         "styled-components": "^6.1.1"
       },
       "devDependencies": {
@@ -17919,9 +17919,9 @@
       }
     },
     "node_modules/review-me-design-system": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/review-me-design-system/-/review-me-design-system-0.0.5.tgz",
-      "integrity": "sha512-lHNrXl/uNtQaTLkw0qdLYivnhQgBHvqIFu76X5llfdLrbG0O9YiiqfjOuXGrEDX2TNFcocne0vMOF3uDbsQXeQ==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/review-me-design-system/-/review-me-design-system-0.0.6.tgz",
+      "integrity": "sha512-XPduANyLXdVVf2mJNBLtaR62sNumebB7CyxoqsIXORH/O3IDayb6ivGRS8ME2SRwikRcrD1lVyefzhHXxAYfag==",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "react-dom": "^18.2.0",
     "react-pdf": "^7.7.0",
     "react-router-dom": "^6.19.0",
-    "review-me-design-system": "^0.0.5",
+    "review-me-design-system": "^0.0.6",
     "styled-components": "^6.1.1"
   },
   "devDependencies": {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -28,7 +28,9 @@ const Header = () => {
         )}
         {!isSMDevice && (
           <RightContainer>
-            <ReviewMe>review me</ReviewMe>
+            <ReviewMe>
+              <Link to={ROUTE_PATH.ROOT}>review me</Link>
+            </ReviewMe>
             <MenuList>
               <MenuItem>
                 <Link to={ROUTE_PATH.RESUME}>이력서</Link>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -41,7 +41,12 @@ const Header = () => {
               </MobileMenuTop>
 
               <MobileMenuList>
-                <MobileMenuItem>
+                <MobileMenuItem
+                  onClick={() => {
+                    setIsOpenMobileMenu(false);
+                    navigate(ROUTE_PATH.RESUME);
+                  }}
+                >
                   <span>이력서 보러가기</span>
                   <Icon iconName="rightArrow" width={28} height={28} />
                 </MobileMenuItem>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -18,6 +18,7 @@ import {
   JoinUsMessage,
   MobileMenuTop,
   MobileMenuButtonContainer,
+  BackDrop,
 } from './style';
 
 const Header = () => {
@@ -75,6 +76,7 @@ const Header = () => {
                 </Button>
               </MobileMenuButtonContainer>
             </MobileMenu>
+            {isOpenMobileMenu && <BackDrop onClick={() => setIsOpenMobileMenu(false)} />}
           </>
         )}
         {!isSMDevice && (

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -66,15 +66,6 @@ const Header = () => {
                   <span>이력서 보러가기</span>
                   <Icon iconName="rightArrow" width={28} height={28} />
                 </MobileMenuItem>
-                <MobileMenuItem
-                  onClick={() => {
-                    handleCloseMobileMenu();
-                    navigate(ROUTE_PATH.MY_RESUME);
-                  }}
-                >
-                  <span>My 이력서 보러가기</span>
-                  <Icon iconName="rightArrow" width={28} height={28} />
-                </MobileMenuItem>
               </MobileMenuList>
 
               <JoinUsMessage>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Button, Icon, theme } from 'review-me-design-system';
 import useMediaQuery from '@hooks/useMediaQuery';
+import { ROUTE_PATH } from '@constants';
 import {
   HeaderLayout,
   LeftContainer,
@@ -27,7 +29,9 @@ const Header = () => {
           <RightContainer>
             <ReviewMe>review me</ReviewMe>
             <MenuList>
-              <MenuItem>이력서</MenuItem>
+              <MenuItem>
+                <Link to={ROUTE_PATH.RESUME}>이력서</Link>
+              </MenuItem>
               <MenuItem>My 이력서</MenuItem>
             </MenuList>
           </RightContainer>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -19,7 +19,7 @@ const Header = () => {
           <ReviewMe>review me</ReviewMe>
           <MenuList>
             <MenuItem>이력서</MenuItem>
-            <MenuItem>자소서</MenuItem>
+            <MenuItem>My 이력서</MenuItem>
           </MenuList>
         </RightContainer>
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button, Icon, theme } from 'review-me-design-system';
+import useMediaQuery from '@hooks/useMediaQuery';
 import {
   HeaderLayout,
   LeftContainer,
@@ -8,28 +9,39 @@ import {
   NavContainer,
   ReviewMe,
   RightContainer,
-  UserInfoButton,
+  IconButton,
 } from './style';
 
 const Header = () => {
+  const { matches: isSMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 600px)' });
+
   return (
     <HeaderLayout>
       <NavContainer>
-        <RightContainer>
-          <ReviewMe>review me</ReviewMe>
-          <MenuList>
-            <MenuItem>이력서</MenuItem>
-            <MenuItem>My 이력서</MenuItem>
-          </MenuList>
-        </RightContainer>
+        {isSMDevice && (
+          <IconButton>
+            <Icon iconName="menu" color={theme.color.accent.text.strong} width={32} height={32} />
+          </IconButton>
+        )}
+        {!isSMDevice && (
+          <RightContainer>
+            <ReviewMe>review me</ReviewMe>
+            <MenuList>
+              <MenuItem>이력서</MenuItem>
+              <MenuItem>My 이력서</MenuItem>
+            </MenuList>
+          </RightContainer>
+        )}
 
         <LeftContainer>
-          <UserInfoButton>
+          <IconButton>
             <Icon iconName="person" color={theme.color.accent.text.strong} width={32} height={32} />
-          </UserInfoButton>
-          <Button variant="default" size="s">
-            로그아웃
-          </Button>
+          </IconButton>
+          {!isSMDevice && (
+            <Button variant="default" size="s">
+              로그아웃
+            </Button>
+          )}
         </LeftContainer>
       </NavContainer>
     </HeaderLayout>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Button, Icon, theme } from 'review-me-design-system';
 import useMediaQuery from '@hooks/useMediaQuery';
@@ -12,19 +12,60 @@ import {
   ReviewMe,
   RightContainer,
   IconButton,
+  MobileMenu,
+  MobileMenuList,
+  MobileMenuItem,
+  JoinUsMessage,
+  MobileMenuTop,
+  MobileMenuButtonContainer,
 } from './style';
 
 const Header = () => {
   const navigate = useNavigate();
   const { matches: isSMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 600px)' });
+  const [isOpenMobileMenu, setIsOpenMobileMenu] = useState<boolean>(false);
 
   return (
     <HeaderLayout>
       <NavContainer>
         {isSMDevice && (
-          <IconButton>
-            <Icon iconName="menu" color={theme.color.accent.text.strong} width={32} height={32} />
-          </IconButton>
+          <>
+            <IconButton onClick={() => setIsOpenMobileMenu(true)}>
+              <Icon iconName="menu" color={theme.color.accent.text.strong} width={28} height={28} />
+            </IconButton>
+            <MobileMenu className={isOpenMobileMenu ? 'open' : ''}>
+              <MobileMenuTop>
+                <IconButton onClick={() => setIsOpenMobileMenu(false)}>
+                  <Icon iconName="xMark" width={28} height={28} />
+                </IconButton>
+              </MobileMenuTop>
+
+              <MobileMenuList>
+                <MobileMenuItem>
+                  <span>이력서 보러가기</span>
+                  <Icon iconName="rightArrow" width={28} height={28} />
+                </MobileMenuItem>
+                <MobileMenuItem>
+                  <span>My 이력서 보러가기</span>
+                  <Icon iconName="rightArrow" width={28} height={28} />
+                </MobileMenuItem>
+              </MobileMenuList>
+
+              <JoinUsMessage>
+                <span>review me에 가입하여</span>
+                <span>다른 사람들과 이력서를 공유해보세요.</span>
+              </JoinUsMessage>
+
+              <MobileMenuButtonContainer>
+                <Button variant="default" size="s">
+                  회원 가입
+                </Button>
+                <Button variant="outline" size="s">
+                  github으로 로그인
+                </Button>
+              </MobileMenuButtonContainer>
+            </MobileMenu>
+          </>
         )}
         {!isSMDevice && (
           <RightContainer>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -50,7 +50,12 @@ const Header = () => {
                   <span>이력서 보러가기</span>
                   <Icon iconName="rightArrow" width={28} height={28} />
                 </MobileMenuItem>
-                <MobileMenuItem>
+                <MobileMenuItem
+                  onClick={() => {
+                    setIsOpenMobileMenu(false);
+                    navigate(ROUTE_PATH.MY_RESUME);
+                  }}
+                >
                   <span>My 이력서 보러가기</span>
                   <Icon iconName="rightArrow" width={28} height={28} />
                 </MobileMenuItem>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { Button, Icon, theme } from 'review-me-design-system';
 import useMediaQuery from '@hooks/useMediaQuery';
 import { ROUTE_PATH } from '@constants';
+import { manageBodyScroll } from '@utils';
 import {
   HeaderLayout,
   LeftContainer,
@@ -26,17 +27,31 @@ const Header = () => {
   const { matches: isSMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 600px)' });
   const [isOpenMobileMenu, setIsOpenMobileMenu] = useState<boolean>(false);
 
+  const handleOpenMobileMenu = () => {
+    if (!isSMDevice) return;
+
+    setIsOpenMobileMenu(true);
+    manageBodyScroll(false);
+  };
+
+  const handleCloseMobileMenu = () => {
+    if (!isSMDevice) return;
+
+    setIsOpenMobileMenu(false);
+    manageBodyScroll(true);
+  };
+
   return (
     <HeaderLayout>
       <NavContainer>
         {isSMDevice && (
           <>
-            <IconButton onClick={() => setIsOpenMobileMenu(true)}>
+            <IconButton onClick={handleOpenMobileMenu}>
               <Icon iconName="menu" color={theme.color.accent.text.strong} width={28} height={28} />
             </IconButton>
             <MobileMenu className={isOpenMobileMenu ? 'open' : ''}>
               <MobileMenuTop>
-                <IconButton onClick={() => setIsOpenMobileMenu(false)}>
+                <IconButton onClick={handleCloseMobileMenu}>
                   <Icon iconName="xMark" width={28} height={28} />
                 </IconButton>
               </MobileMenuTop>
@@ -44,7 +59,7 @@ const Header = () => {
               <MobileMenuList>
                 <MobileMenuItem
                   onClick={() => {
-                    setIsOpenMobileMenu(false);
+                    handleCloseMobileMenu();
                     navigate(ROUTE_PATH.RESUME);
                   }}
                 >
@@ -53,7 +68,7 @@ const Header = () => {
                 </MobileMenuItem>
                 <MobileMenuItem
                   onClick={() => {
-                    setIsOpenMobileMenu(false);
+                    handleCloseMobileMenu();
                     navigate(ROUTE_PATH.MY_RESUME);
                   }}
                 >
@@ -76,7 +91,7 @@ const Header = () => {
                 </Button>
               </MobileMenuButtonContainer>
             </MobileMenu>
-            {isOpenMobileMenu && <BackDrop onClick={() => setIsOpenMobileMenu(false)} />}
+            {isOpenMobileMenu && <BackDrop onClick={handleCloseMobileMenu} />}
           </>
         )}
         {!isSMDevice && (

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Button, Icon, theme } from 'review-me-design-system';
 import useMediaQuery from '@hooks/useMediaQuery';
 import { ROUTE_PATH } from '@constants';
@@ -15,6 +15,7 @@ import {
 } from './style';
 
 const Header = () => {
+  const navigate = useNavigate();
   const { matches: isSMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 600px)' });
 
   return (
@@ -38,7 +39,13 @@ const Header = () => {
         )}
 
         <LeftContainer>
-          <IconButton>
+          <IconButton
+            onClick={() => {
+              // * 로그인 된 상태일 경우 마이페이지로 이동
+              navigate(ROUTE_PATH.MY_PAGE);
+              // todo: 로그인하지 않았을 경우 로그인 유도하는 로직 구현하기
+            }}
+          >
             <Icon iconName="person" color={theme.color.accent.text.strong} width={32} height={32} />
           </IconButton>
           {!isSMDevice && (

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -78,7 +78,7 @@ const IconButton = styled.button`
 const MobileMenu = styled.aside`
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
   flex-shrink: 0;
   position: fixed;
   top: 0;
@@ -134,6 +134,16 @@ const MobileMenuButtonContainer = styled.div`
   gap: 0.5rem;
 `;
 
+const BackDrop = styled.div`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgb(0 0 0 / 0.5);
+  z-index: ${({ theme }) => theme.zIndex.backDrop};
+`;
+
 export {
   HeaderLayout,
   NavContainer,
@@ -149,4 +159,5 @@ export {
   MobileMenuItem,
   JoinUsMessage,
   MobileMenuButtonContainer,
+  BackDrop,
 };

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -3,17 +3,22 @@ import styled from 'styled-components';
 
 const HeaderLayout = styled.header`
   width: 100%;
+  height: 3.75rem;
   padding: 0 2rem;
 
   background: ${theme.color.neutral.bg.default};
   border-bottom: 1px solid ${theme.palette.grey300};
+
+  @media screen and (max-width: 600px) {
+    padding: 0 0.5rem;
+  }
 `;
 
 const NavContainer = styled.nav`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 4rem;
+  height: 100%;
 `;
 
 const RightContainer = styled.div`
@@ -61,7 +66,7 @@ const LeftContainer = styled.div`
   flex-shrink: 0;
 `;
 
-const UserInfoButton = styled.button`
+const IconButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -79,5 +84,5 @@ export {
   MenuList,
   MenuItem,
   LeftContainer,
-  UserInfoButton,
+  IconButton,
 };

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -75,6 +75,65 @@ const IconButton = styled.button`
   cursor: pointer;
 `;
 
+const MobileMenu = styled.aside`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 80%;
+  height: 100vh;
+  padding: 0.5rem 1.875rem;
+  transform: translateX(-80%);
+  visibility: hidden;
+
+  background-color: ${theme.color.neutral.bg.default};
+  transition: all 0.2s;
+
+  z-index: ${theme.zIndex.modal};
+  &.open {
+    transform: translateX(0);
+    display: flex;
+    visibility: visible;
+  }
+`;
+
+const MobileMenuTop = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const MobileMenuList = styled.ul`
+  display: flex;
+  flex-direction: column;
+`;
+
+const MobileMenuItem = styled.li`
+  display: flex;
+  padding: 0.5rem 0;
+  justify-content: space-between;
+  align-items: center;
+
+  ${theme.font.title.default}
+  color: ${theme.color.neutral.text.default};
+`;
+
+const JoinUsMessage = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0rem;
+
+  ${theme.font.body.weak}
+  color: ${theme.color.neutral.text.default};
+`;
+
+const MobileMenuButtonContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
 export {
   HeaderLayout,
   NavContainer,
@@ -84,4 +143,10 @@ export {
   MenuItem,
   LeftContainer,
   IconButton,
+  MobileMenu,
+  MobileMenuTop,
+  MobileMenuList,
+  MobileMenuItem,
+  JoinUsMessage,
+  MobileMenuButtonContainer,
 };

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -46,7 +46,6 @@ const MenuList = styled.ul`
 const MenuItem = styled.li`
   display: flex;
   align-items: center;
-  height: 100%;
   padding: 0 1rem;
 
   color: ${theme.color.neutral.text.default};

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Header from '@components/Header';
+
+const Layout = () => {
+  return (
+    <>
+      <Header />
+      <Outlet />
+    </>
+  );
+};
+
+export default Layout;

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+interface Props {
+  mediaQueryString: string;
+}
+
+const useMediaQuery = ({ mediaQueryString }: Props) => {
+  const [matches, setMatches] = useState<boolean>(window.matchMedia(mediaQueryString).matches);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(mediaQueryString);
+    const handleMediaQuery = (e: MediaQueryListEvent) => {
+      setMatches(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleMediaQuery);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleMediaQuery);
+    };
+  }, [mediaQueryString]);
+
+  return { matches };
+};
+
+export default useMediaQuery;

--- a/src/pages/MyResume/index.tsx
+++ b/src/pages/MyResume/index.tsx
@@ -1,66 +1,62 @@
 import React from 'react';
 import { Button, useModal } from 'review-me-design-system';
-import Header from '@components/Header';
 import ResumeUploadModal from '@components/Modal/ResumeUploadModal';
 import MyResumeItem from '@components/MyResumeItem';
-import { Main, MyResumeLayout, MyResumeList } from './style';
+import { Main, MyResumeList } from './style';
 
 const MyResume = () => {
   const { isOpen: isOpenUploadModal, open: openUploadModal, close: closeUploadModal } = useModal();
 
   return (
-    <MyResumeLayout>
-      <Header />
-      <Main>
-        <Button variant="default" size="m" onClick={openUploadModal}>
-          이력서 pdf 올리기
-        </Button>
-        <ResumeUploadModal isOpen={isOpenUploadModal} onClose={closeUploadModal} />
+    <Main>
+      <Button variant="default" size="m" onClick={openUploadModal}>
+        이력서 pdf 올리기
+      </Button>
+      <ResumeUploadModal isOpen={isOpenUploadModal} onClose={closeUploadModal} />
 
-        <MyResumeList>
-          <MyResumeItem
-            id={1}
-            title="이력서 제목"
-            year={0}
-            occupation="backend"
-            scope="전체 공개"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <MyResumeItem
-            id={2}
-            title="이력서 제목"
-            year={0}
-            occupation="backend"
-            scope="전체 공개"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <MyResumeItem
-            id={3}
-            title="이력서 제목"
-            year={0}
-            occupation="backend"
-            scope="전체 공개"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <MyResumeItem
-            id={4}
-            title="이력서 제목"
-            year={0}
-            occupation="backend"
-            scope="전체 공개"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <MyResumeItem
-            id={5}
-            title="이력서 제목"
-            year={0}
-            occupation="backend"
-            scope="전체 공개"
-            createdAt="2023-12-22 15:16:42"
-          />
-        </MyResumeList>
-      </Main>
-    </MyResumeLayout>
+      <MyResumeList>
+        <MyResumeItem
+          id={1}
+          title="이력서 제목"
+          year={0}
+          occupation="backend"
+          scope="전체 공개"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <MyResumeItem
+          id={2}
+          title="이력서 제목"
+          year={0}
+          occupation="backend"
+          scope="전체 공개"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <MyResumeItem
+          id={3}
+          title="이력서 제목"
+          year={0}
+          occupation="backend"
+          scope="전체 공개"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <MyResumeItem
+          id={4}
+          title="이력서 제목"
+          year={0}
+          occupation="backend"
+          scope="전체 공개"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <MyResumeItem
+          id={5}
+          title="이력서 제목"
+          year={0}
+          occupation="backend"
+          scope="전체 공개"
+          createdAt="2023-12-22 15:16:42"
+        />
+      </MyResumeList>
+    </Main>
   );
 };
 

--- a/src/pages/Resume/index.tsx
+++ b/src/pages/Resume/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Button, Select } from 'review-me-design-system';
-import Header from '@components/Header';
 import ResumeItem from '@components/ResumeItem';
 import { Filter, FilterContainer, Main, MainHeader, ResumeList } from './style';
 
@@ -28,107 +27,103 @@ const Resume = () => {
   ];
 
   return (
-    <>
-      <Header />
+    <Main>
+      <MainHeader>
+        <FilterContainer>
+          <Filter>
+            <span>직군</span>
+            <Select width="10rem">
+              <Select.TriggerButton />
+              <Select.OptionList>
+                {scope.map((option) => {
+                  return (
+                    <Select.OptionItem key={option.value} value={option.value} label={option.label}>
+                      {option.label}
+                    </Select.OptionItem>
+                  );
+                })}
+              </Select.OptionList>
+            </Select>
+          </Filter>
+          <Filter>
+            <span>경력</span>
+            <Select width="10rem">
+              <Select.TriggerButton />
+              <Select.OptionList>
+                {yearOptions.map((option) => {
+                  return (
+                    <Select.OptionItem key={option.value} value={option.value} label={option.label}>
+                      {option.label}
+                    </Select.OptionItem>
+                  );
+                })}
+              </Select.OptionList>
+            </Select>
+          </Filter>
+        </FilterContainer>
 
-      <Main>
-        <MainHeader>
-          <FilterContainer>
-            <Filter>
-              <span>직군</span>
-              <Select width="10rem">
-                <Select.TriggerButton />
-                <Select.OptionList>
-                  {scope.map((option) => {
-                    return (
-                      <Select.OptionItem key={option.value} value={option.value} label={option.label}>
-                        {option.label}
-                      </Select.OptionItem>
-                    );
-                  })}
-                </Select.OptionList>
-              </Select>
-            </Filter>
-            <Filter>
-              <span>경력</span>
-              <Select width="10rem">
-                <Select.TriggerButton />
-                <Select.OptionList>
-                  {yearOptions.map((option) => {
-                    return (
-                      <Select.OptionItem key={option.value} value={option.value} label={option.label}>
-                        {option.label}
-                      </Select.OptionItem>
-                    );
-                  })}
-                </Select.OptionList>
-              </Select>
-            </Filter>
-          </FilterContainer>
+        <Button variant="default" size="m">
+          내 이력서 보러가기
+        </Button>
+      </MainHeader>
 
-          <Button variant="default" size="m">
-            내 이력서 보러가기
-          </Button>
-        </MainHeader>
-
-        <ResumeList>
-          <ResumeItem
-            id={1}
-            title="이력서"
-            writerName="aken-you"
-            writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-            year={0}
-            occupation="DevOps System Engineer"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <ResumeItem
-            id={2}
-            title="이력서"
-            writerName="aken-you"
-            writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-            year={0}
-            occupation="DevOps System Engineer"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <ResumeItem
-            id={3}
-            title="이력서"
-            writerName="aken-you"
-            writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-            year={0}
-            occupation="DevOps System Engineer"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <ResumeItem
-            id={4}
-            title="이력서"
-            writerName="aken-you"
-            writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-            year={0}
-            occupation="DevOps System Engineer"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <ResumeItem
-            id={5}
-            title="이력서"
-            writerName="aken-you"
-            writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-            year={0}
-            occupation="DevOps System Engineer"
-            createdAt="2023-12-22 15:16:42"
-          />
-          <ResumeItem
-            id={6}
-            title="이력서"
-            writerName="aken-you"
-            writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-            year={0}
-            occupation="DevOps System Engineer"
-            createdAt="2023-12-22 15:16:42"
-          />
-        </ResumeList>
-      </Main>
-    </>
+      <ResumeList>
+        <ResumeItem
+          id={1}
+          title="이력서"
+          writerName="aken-you"
+          writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
+          year={0}
+          occupation="DevOps System Engineer"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <ResumeItem
+          id={2}
+          title="이력서"
+          writerName="aken-you"
+          writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
+          year={0}
+          occupation="DevOps System Engineer"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <ResumeItem
+          id={3}
+          title="이력서"
+          writerName="aken-you"
+          writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
+          year={0}
+          occupation="DevOps System Engineer"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <ResumeItem
+          id={4}
+          title="이력서"
+          writerName="aken-you"
+          writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
+          year={0}
+          occupation="DevOps System Engineer"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <ResumeItem
+          id={5}
+          title="이력서"
+          writerName="aken-you"
+          writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
+          year={0}
+          occupation="DevOps System Engineer"
+          createdAt="2023-12-22 15:16:42"
+        />
+        <ResumeItem
+          id={6}
+          title="이력서"
+          writerName="aken-you"
+          writerProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
+          year={0}
+          occupation="DevOps System Engineer"
+          createdAt="2023-12-22 15:16:42"
+        />
+      </ResumeList>
+    </Main>
   );
 };
 

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Button, Label, Textarea } from 'review-me-design-system';
 import Comment from '@components/Comment';
-import Header from '@components/Header';
 import PdfViewer from '@components/PdfViewer';
 import {
   Career,
@@ -33,152 +32,142 @@ const ResumeDetail = () => {
   const [currentTab, setCurrentTab] = useState<ActiveTab>('feedback');
 
   return (
-    <>
-      <Header />
+    <Main>
+      <ResumeContentWrapper>
+        <ResumeViewer>
+          <ResumeViewerHeader>
+            <ResumeInfo>
+              <Title>네이버 신입 프론트 공채 준비</Title>
 
-      <Main>
-        <ResumeContentWrapper>
-          <ResumeViewer>
-            <ResumeViewerHeader>
-              <ResumeInfo>
-                <Title>네이버 신입 프론트 공채 준비</Title>
+              <WriterInfoContainer>
+                <WriterImg />
+                <WriterInfo>
+                  <span>aken-you</span>
+                  <Career>Frontend | 신입</Career>
+                </WriterInfo>
+              </WriterInfoContainer>
+            </ResumeInfo>
+          </ResumeViewerHeader>
 
-                <WriterInfoContainer>
-                  <WriterImg />
-                  <WriterInfo>
-                    <span>aken-you</span>
-                    <Career>Frontend | 신입</Career>
-                  </WriterInfo>
-                </WriterInfoContainer>
-              </ResumeInfo>
-            </ResumeViewerHeader>
+          <PdfViewer file={file} numPages={numPages} onLoadSuccess={setNumPages} width="100%" height="100%" />
+        </ResumeViewer>
 
-            <PdfViewer
-              file={file}
-              numPages={numPages}
-              onLoadSuccess={setNumPages}
-              width="100%"
-              height="100%"
-            />
-          </ResumeViewer>
+        <FeedbackAndQuestion>
+          <TabList>
+            <Tab $isActive={currentTab === 'feedback'} onClick={() => setCurrentTab('feedback')}>
+              피드백
+            </Tab>
+            <Tab $isActive={currentTab === 'question'} onClick={() => setCurrentTab('question')}>
+              예상질문
+            </Tab>
+            <Tab $isActive={currentTab === 'comment'} onClick={() => setCurrentTab('comment')}>
+              댓글
+            </Tab>
+          </TabList>
 
-          <FeedbackAndQuestion>
-            <TabList>
-              <Tab $isActive={currentTab === 'feedback'} onClick={() => setCurrentTab('feedback')}>
-                피드백
-              </Tab>
-              <Tab $isActive={currentTab === 'question'} onClick={() => setCurrentTab('question')}>
-                예상질문
-              </Tab>
-              <Tab $isActive={currentTab === 'comment'} onClick={() => setCurrentTab('comment')}>
-                댓글
-              </Tab>
-            </TabList>
-
-            <CommentList>
-              <li>
+          <CommentList>
+            <li>
+              <Comment
+                content="뭔가 이력서에 문제 해결과 관련된 내용이 부족한 것같아요."
+                commenterId={2}
+                commenterName="acceptor-gyu"
+                commenterProfileUrl="https://avatars.githubusercontent.com/u/71162390?v=4"
+                labelContent="자기소개"
+                createdAt="2023-12-22 15:46:05"
+                countOfReplies={0}
+                checked={false}
+                emojis={[
+                  {
+                    id: 2,
+                    count: 2,
+                  },
+                  {
+                    id: 3,
+                    count: 1,
+                  },
+                ]}
+                myEmojiId={2}
+              />
+              <ReplyList>
                 <Comment
-                  content="뭔가 이력서에 문제 해결과 관련된 내용이 부족한 것같아요."
-                  commenterId={2}
-                  commenterName="acceptor-gyu"
-                  commenterProfileUrl="https://avatars.githubusercontent.com/u/71162390?v=4"
-                  labelContent="자기소개"
-                  createdAt="2023-12-22 15:46:05"
-                  countOfReplies={0}
-                  checked={false}
+                  content="프로젝트에서 react-query를 사용하셨는데 사용한 이유가 궁금합니다."
+                  commenterId={1}
+                  writerId={1}
+                  commenterName="aken-you"
+                  commenterProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
+                  createdAt="2024-01-24 16:19:37"
                   emojis={[
                     {
-                      id: 2,
-                      count: 2,
+                      id: 1,
+                      count: 10,
                     },
-                    {
-                      id: 3,
-                      count: 1,
-                    },
-                  ]}
-                  myEmojiId={2}
-                />
-                <ReplyList>
-                  <Comment
-                    content="프로젝트에서 react-query를 사용하셨는데 사용한 이유가 궁금합니다."
-                    commenterId={1}
-                    writerId={1}
-                    commenterName="aken-you"
-                    commenterProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-                    createdAt="2024-01-24 16:19:37"
-                    emojis={[
-                      {
-                        id: 1,
-                        count: 10,
-                      },
-                      {
-                        id: 2,
-                        count: 3,
-                      },
-                    ]}
-                    myEmojiId={1}
-                  />
-                  <ReplyForm>
-                    <Textarea placeholder="댓글" />
-                    <Button variant="default" size="s">
-                      작성
-                    </Button>
-                  </ReplyForm>
-                </ReplyList>
-              </li>
-
-              <li>
-                <Comment
-                  content="뭔가 이력서에 문제 해결과 관련된 내용이 부족한 것같아요."
-                  commenterId={2}
-                  commenterName="acceptor-gyu"
-                  commenterProfileUrl="https://avatars.githubusercontent.com/u/71162390?v=4"
-                  labelContent="자기소개"
-                  createdAt="2023-12-22 15:46:05"
-                  countOfReplies={0}
-                  checked={false}
-                  emojis={[
                     {
                       id: 2,
-                      count: 2,
-                    },
-                    {
-                      id: 3,
-                      count: 1,
+                      count: 3,
                     },
                   ]}
-                  myEmojiId={2}
+                  myEmojiId={1}
                 />
-              </li>
-            </CommentList>
+                <ReplyForm>
+                  <Textarea placeholder="댓글" />
+                  <Button variant="default" size="s">
+                    작성
+                  </Button>
+                </ReplyForm>
+              </ReplyList>
+            </li>
 
-            <FeedbackForm>
-              <LabelList>
-                {/* todo: label api에서 받아온 데이터로 바꾸기 */}
-                <Label isActive={false} py="0.25rem" px="0.75rem">
-                  프로젝트
-                </Label>
-                <Label isActive={false} py="0.25rem" px="0.75rem">
-                  자기소개
-                </Label>
-                <Label isActive={false} py="0.25rem" px="0.75rem">
-                  협업
-                </Label>
-                <Label isActive={false} py="0.25rem" px="0.75rem">
-                  기타
-                </Label>
-              </LabelList>
-              <FeedbackFormContent>
-                <Textarea placeholder="피드백" />
-                <Button variant="default" size="s">
-                  작성
-                </Button>
-              </FeedbackFormContent>
-            </FeedbackForm>
-          </FeedbackAndQuestion>
-        </ResumeContentWrapper>
-      </Main>
-    </>
+            <li>
+              <Comment
+                content="뭔가 이력서에 문제 해결과 관련된 내용이 부족한 것같아요."
+                commenterId={2}
+                commenterName="acceptor-gyu"
+                commenterProfileUrl="https://avatars.githubusercontent.com/u/71162390?v=4"
+                labelContent="자기소개"
+                createdAt="2023-12-22 15:46:05"
+                countOfReplies={0}
+                checked={false}
+                emojis={[
+                  {
+                    id: 2,
+                    count: 2,
+                  },
+                  {
+                    id: 3,
+                    count: 1,
+                  },
+                ]}
+                myEmojiId={2}
+              />
+            </li>
+          </CommentList>
+
+          <FeedbackForm>
+            <LabelList>
+              {/* todo: label api에서 받아온 데이터로 바꾸기 */}
+              <Label isActive={false} py="0.25rem" px="0.75rem">
+                프로젝트
+              </Label>
+              <Label isActive={false} py="0.25rem" px="0.75rem">
+                자기소개
+              </Label>
+              <Label isActive={false} py="0.25rem" px="0.75rem">
+                협업
+              </Label>
+              <Label isActive={false} py="0.25rem" px="0.75rem">
+                기타
+              </Label>
+            </LabelList>
+            <FeedbackFormContent>
+              <Textarea placeholder="피드백" />
+              <Button variant="default" size="s">
+                작성
+              </Button>
+            </FeedbackFormContent>
+          </FeedbackForm>
+        </FeedbackAndQuestion>
+      </ResumeContentWrapper>
+    </Main>
   );
 };
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
+import Layout from '@components/Layout';
 import MainPage from '@pages/MainPage';
 import MyPage from '@pages/MyPage';
 import MyResume from '@pages/MyResume';
@@ -9,11 +10,17 @@ import ResumeDetail from '@pages/ResumeDetail';
 import { ROUTE_PATH } from '@constants';
 
 const router = createBrowserRouter([
-  { path: ROUTE_PATH.ROOT, element: <MainPage /> },
-  { path: ROUTE_PATH.MY_PAGE, element: <MyPage /> },
-  { path: ROUTE_PATH.RESUME, element: <Resume /> },
-  { path: `${ROUTE_PATH.RESUME}/:id`, element: <ResumeDetail /> },
-  { path: ROUTE_PATH.MY_RESUME, element: <MyResume /> },
+  {
+    path: ROUTE_PATH.ROOT,
+    element: <Layout />,
+    children: [
+      { index: true, element: <MainPage /> },
+      { path: ROUTE_PATH.MY_PAGE, element: <MyPage /> },
+      { path: ROUTE_PATH.RESUME, element: <Resume /> },
+      { path: `${ROUTE_PATH.RESUME}/:id`, element: <ResumeDetail /> },
+      { path: ROUTE_PATH.MY_RESUME, element: <MyResume /> },
+    ],
+  },
 ]);
 
 export default router;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -3,7 +3,7 @@ import { createGlobalStyle } from 'styled-components';
 
 export const GlobalStyle = createGlobalStyle`
   body {
-    overflow: visible;
+    overflow: auto;
     min-height: 100%;
     background-color: ${theme.color.neutral.bg.light};
   }

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -7,4 +7,8 @@ export const GlobalStyle = createGlobalStyle`
     min-height: 100%;
     background-color: ${theme.color.neutral.bg.light};
   }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 `;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,3 +9,11 @@ export const formatDate = (date: string) => {
 
   return formattedDate;
 };
+
+export const manageBodyScroll = (canScroll: boolean) => {
+  if (canScroll) {
+    document.body.style.overflow = 'auto';
+    return;
+  }
+  document.body.style.overflow = 'hidden';
+};


### PR DESCRIPTION
## 개요

화면의 가로 해상도가 600 이하일 경우, 다른 페이지로 이동하는 menu 목록을 menu icon을 클릭할 경우 나타나게 구현했다.

기존 header (가로 해상도가 600 초과일 경우)
<img width="981" alt="스크린샷 2024-01-30 오전 12 40 24" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/24a18736-716c-4e73-bc70-f8ea3e235cbd">

mobile header (가로 해상도가 600 이하일 경우)

<img width="451" alt="스크린샷 2024-01-30 오전 12 41 18" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/3565be64-b543-4261-b079-2779d9d42ff4">

https://github.com/review-me-Team/review-me-fe/assets/96980857/41250328-5c00-49f3-ae9d-e7eb281c27bc


## 작업 사항

- 해상도가 600이하일 경우, 왼쪽에서 나타나는 menu 목록 컴포넌트 생성
- Header 컴포넌트 반응형 구현

## 이슈 번호

close #28 