### PR TITLE
[FE] 이력서 상세 페이지에서 각 탭에 대한 form UI

### DIFF
--- a/src/apis/utilApi.ts
+++ b/src/apis/utilApi.ts
@@ -57,3 +57,59 @@ export const getScopeList = async () => {
 export const useScopeList = () => {
   return useQuery({ queryKey: ['scopeList'], queryFn: getScopeList });
 };
+
+// GET 이모지 목록 조회
+export interface Emoji {
+  id: number;
+  count: number;
+}
+
+interface GetEmojiList {
+  emojis: Emoji[];
+}
+
+export const getEmojiList = async () => {
+  const response = await fetch(REQUEST_URL.EMOJI);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const {
+    data: { emojis },
+  }: ApiResponse<GetEmojiList> = await response.json();
+
+  return emojis;
+};
+
+export const useEmojiList = () => {
+  return useQuery({ queryKey: ['emojiList'], queryFn: getEmojiList });
+};
+
+// GET 라벨 목록 조회
+export interface Label {
+  id: number;
+  label: string;
+}
+
+interface GetLabelList {
+  labels: Label[];
+}
+
+export const getLabelList = async () => {
+  const response = await fetch(REQUEST_URL.LABEL);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const {
+    data: { labels },
+  }: ApiResponse<GetLabelList> = await response.json();
+
+  return labels;
+};
+
+export const useLabelList = () => {
+  return useQuery({ queryKey: ['labelList'], queryFn: getLabelList });
+};

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -9,7 +9,7 @@ import {
   CommentList,
   FeedbackAndQuestion,
   Form,
-  FeedbackFormContent,
+  FormContent,
   LabelList,
   Main,
   ResumeContentWrapper,
@@ -220,12 +220,12 @@ const ResumeDetail = () => {
                 );
               })}
             </LabelList>
-            <FeedbackFormContent>
+            <FormContent>
               <Textarea placeholder="피드백" />
               <Button variant="default" size="s">
                 작성
               </Button>
-            </FeedbackFormContent>
+            </FormContent>
           </Form>
         </FeedbackAndQuestion>
       </ResumeContentWrapper>

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Icon, Label, Textarea } from 'review-me-design-system';
+import { Button, Icon, Input, Label, Textarea } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
 import PdfViewer from '@components/PdfViewer';
@@ -27,6 +27,7 @@ import {
   PdfViewerContainer,
   PdfViewerInfo,
   PdfPagesInfo,
+  KeywordLabel,
 } from './style';
 
 type ActiveTab = 'feedback' | 'question' | 'comment';
@@ -46,11 +47,13 @@ const ResumeDetail = () => {
   const [scale, setScale] = useState<number>(INIT_SCALE);
   const [currentTab, setCurrentTab] = useState<ActiveTab>('feedback');
 
+  const [labelContent, setLabelContent] = useState<string>('');
+
   const { data: labelList } = useLabelList();
 
   const textareaPlaceholder = {
     feedback: '피드백',
-    question: '예상 질문',
+    question: '예상질문',
     comment: '댓글',
   };
 
@@ -227,6 +230,12 @@ const ResumeDetail = () => {
                   );
                 })}
               </LabelList>
+            )}
+            {currentTab === 'question' && (
+              <>
+                <KeywordLabel>{labelContent}</KeywordLabel>
+                <Input placeholder="예상질문 키워드" onChange={(e) => setLabelContent(e.target.value)} />
+              </>
             )}
             <FormContent>
               <Textarea placeholder={textareaPlaceholder[currentTab] || ''} />

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -48,6 +48,12 @@ const ResumeDetail = () => {
 
   const { data: labelList } = useLabelList();
 
+  const textareaPlaceholder = {
+    feedback: '피드백',
+    question: '예상 질문',
+    comment: '댓글',
+  };
+
   return (
     <Main>
       <ResumeContentWrapper>
@@ -211,17 +217,19 @@ const ResumeDetail = () => {
           </CommentList>
 
           <Form>
-            <LabelList>
-              {labelList?.map(({ id, label }) => {
-                return (
-                  <Label key={id} isActive={false} py="0.25rem" px="0.75rem">
-                    {label}
-                  </Label>
-                );
-              })}
-            </LabelList>
+            {currentTab === 'feedback' && (
+              <LabelList>
+                {labelList?.map(({ id, label }) => {
+                  return (
+                    <Label key={id} isActive={false} py="0.25rem" px="0.75rem">
+                      {label}
+                    </Label>
+                  );
+                })}
+              </LabelList>
+            )}
             <FormContent>
-              <Textarea placeholder="피드백" />
+              <Textarea placeholder={textareaPlaceholder[currentTab] || ''} />
               <Button variant="default" size="s">
                 작성
               </Button>

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -7,7 +7,7 @@ import {
   Career,
   CommentList,
   FeedbackAndQuestion,
-  FeedbackForm,
+  Form,
   FeedbackFormContent,
   LabelList,
   Main,
@@ -207,7 +207,7 @@ const ResumeDetail = () => {
             </li>
           </CommentList>
 
-          <FeedbackForm>
+          <Form>
             <LabelList>
               {/* todo: label api에서 받아온 데이터로 바꾸기 */}
               <Label isActive={false} py="0.25rem" px="0.75rem">
@@ -229,7 +229,7 @@ const ResumeDetail = () => {
                 작성
               </Button>
             </FeedbackFormContent>
-          </FeedbackForm>
+          </Form>
         </FeedbackAndQuestion>
       </ResumeContentWrapper>
     </Main>

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { MouseEvent, useState } from 'react';
 import { Button, Icon, Input, Label, Textarea } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
@@ -48,6 +48,7 @@ const ResumeDetail = () => {
   const [currentTab, setCurrentTab] = useState<ActiveTab>('feedback');
 
   const [labelContent, setLabelContent] = useState<string>('');
+  const [comment, setComment] = useState<string>('');
 
   const { data: labelList } = useLabelList();
 
@@ -55,6 +56,12 @@ const ResumeDetail = () => {
     feedback: '피드백',
     question: '예상질문',
     comment: '댓글',
+  };
+
+  const handleTabClick = (e: MouseEvent<HTMLButtonElement>, tab: ActiveTab) => {
+    setCurrentTab(tab);
+    setLabelContent('');
+    setComment('');
   };
 
   return (
@@ -131,13 +138,13 @@ const ResumeDetail = () => {
 
         <FeedbackAndQuestion>
           <TabList>
-            <Tab $isActive={currentTab === 'feedback'} onClick={() => setCurrentTab('feedback')}>
+            <Tab $isActive={currentTab === 'feedback'} onClick={(e) => handleTabClick(e, 'feedback')}>
               피드백
             </Tab>
-            <Tab $isActive={currentTab === 'question'} onClick={() => setCurrentTab('question')}>
+            <Tab $isActive={currentTab === 'question'} onClick={(e) => handleTabClick(e, 'question')}>
               예상질문
             </Tab>
-            <Tab $isActive={currentTab === 'comment'} onClick={() => setCurrentTab('comment')}>
+            <Tab $isActive={currentTab === 'comment'} onClick={(e) => handleTabClick(e, 'comment')}>
               댓글
             </Tab>
           </TabList>
@@ -238,7 +245,11 @@ const ResumeDetail = () => {
               </>
             )}
             <FormContent>
-              <Textarea placeholder={textareaPlaceholder[currentTab] || ''} />
+              <Textarea
+                placeholder={textareaPlaceholder[currentTab] || ''}
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+              />
               <Button variant="default" size="s">
                 작성
               </Button>

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -4,6 +4,7 @@ import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
 import PdfViewer from '@components/PdfViewer';
 import { useLabelList } from '@apis/utilApi';
+import { PDF_VIEWER_SCALE } from '@constants';
 import {
   Career,
   CommentList,
@@ -33,18 +34,17 @@ import {
 type ActiveTab = 'feedback' | 'question' | 'comment';
 
 const ResumeDetail = () => {
-  // * 초기값 임시로 설정
   const INIT_CURRENT_PAGE_NUM = 1;
-  const INIT_SCALE = 1.2;
-  const MAX_SCALE = 2;
-  const MIN_SCALE = 0.6;
-  const SCALE_STEP = 0.2;
+  const { INIT_SCALE, MAX_SCALE, MIN_SCALE, SCALE_STEP } = PDF_VIEWER_SCALE;
+
   const [file, setFile] = useState<string | undefined>(
     `${process.env.BASE_PDF_URL}/ad6c62c6이력서_샘플.pdf`,
   );
+
   const [numPages, setNumPages] = useState<number>();
   const [currentPageNum, setCurrentPageNum] = useState<number>(INIT_CURRENT_PAGE_NUM);
   const [scale, setScale] = useState<number>(INIT_SCALE);
+
   const [currentTab, setCurrentTab] = useState<ActiveTab>('feedback');
 
   const [labelContent, setLabelContent] = useState<string>('');

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -3,6 +3,7 @@ import { Button, Icon, Label, Textarea } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
 import PdfViewer from '@components/PdfViewer';
+import { useLabelList } from '@apis/utilApi';
 import {
   Career,
   CommentList,
@@ -44,6 +45,8 @@ const ResumeDetail = () => {
   const [currentPageNum, setCurrentPageNum] = useState<number>(INIT_CURRENT_PAGE_NUM);
   const [scale, setScale] = useState<number>(INIT_SCALE);
   const [currentTab, setCurrentTab] = useState<ActiveTab>('feedback');
+
+  const { data: labelList } = useLabelList();
 
   return (
     <Main>
@@ -209,19 +212,13 @@ const ResumeDetail = () => {
 
           <Form>
             <LabelList>
-              {/* todo: label api에서 받아온 데이터로 바꾸기 */}
-              <Label isActive={false} py="0.25rem" px="0.75rem">
-                프로젝트
-              </Label>
-              <Label isActive={false} py="0.25rem" px="0.75rem">
-                자기소개
-              </Label>
-              <Label isActive={false} py="0.25rem" px="0.75rem">
-                협업
-              </Label>
-              <Label isActive={false} py="0.25rem" px="0.75rem">
-                기타
-              </Label>
+              {labelList?.map(({ id, label }) => {
+                return (
+                  <Label key={id} isActive={false} py="0.25rem" px="0.75rem">
+                    {label}
+                  </Label>
+                );
+              })}
             </LabelList>
             <FeedbackFormContent>
               <Textarea placeholder="피드백" />

--- a/src/pages/ResumeDetail/style.ts
+++ b/src/pages/ResumeDetail/style.ts
@@ -179,6 +179,21 @@ const ReplyForm = styled.form`
   }
 `;
 
+const KeywordLabel = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: fit-content;
+  height: 1.5rem;
+  padding: 0 1rem;
+
+  background: ${theme.color.accent.bg.strong};
+  border-radius: 1rem;
+
+  ${theme.font.label}
+  color: ${theme.color.neutral.text.weak}
+`;
+
 // * 댓글 관련
 const CommentList = styled.ul`
   display: flex;
@@ -215,6 +230,7 @@ export {
   Tab,
   Form,
   FormContent,
+  KeywordLabel,
   LabelList,
   CommentList,
   ReplyList,

--- a/src/pages/ResumeDetail/style.ts
+++ b/src/pages/ResumeDetail/style.ts
@@ -138,10 +138,11 @@ const Tab = styled.button<{ $isActive: boolean }>`
   cursor: pointer;
 `;
 
-const FeedbackForm = styled.form`
+const Form = styled.form`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: 0.75rem;
   padding: 0.75rem 1rem;
 
   box-shadow: rgba(0, 0, 0, 0.07) 0 0 1.25rem;
@@ -149,7 +150,6 @@ const FeedbackForm = styled.form`
 
 const LabelList = styled.div`
   display: flex;
-  margin-bottom: 0.75rem;
   align-items: center;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -179,8 +179,6 @@ const ReplyForm = styled.form`
   }
 `;
 
-const QuestionForm = styled.form``;
-
 // * 댓글 관련
 const CommentList = styled.ul`
   display: flex;
@@ -197,10 +195,6 @@ const ReplyList = styled.ul`
 
   background-color: ${theme.palette.green100};
 `;
-
-// * Main 하단: 댓글
-
-const CommentForm = styled.form``;
 
 export {
   Main,
@@ -219,11 +213,10 @@ export {
   FeedbackAndQuestion,
   TabList,
   Tab,
-  FeedbackForm,
+  Form,
   FeedbackFormContent,
   LabelList,
   CommentList,
   ReplyList,
   ReplyForm,
-  CommentForm,
 };

--- a/src/pages/ResumeDetail/style.ts
+++ b/src/pages/ResumeDetail/style.ts
@@ -155,7 +155,7 @@ const LabelList = styled.div`
   gap: 0.5rem;
 `;
 
-const FeedbackFormContent = styled.div`
+const FormContent = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -214,7 +214,7 @@ export {
   TabList,
   Tab,
   Form,
-  FeedbackFormContent,
+  FormContent,
   LabelList,
   CommentList,
   ReplyList,


### PR DESCRIPTION
## 개요

이력서 상세 페이지에서 피드백, 예상질문, 댓글 탭에 대한 form UI를 구현했다.

## 작업 사항

- [x] 피드백 form
<img width="567" alt="스크린샷 2024-02-19 오전 11 33 56" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/d1b0e1df-0079-428a-a006-8bbd2d03c046">

- [x] 예상질문 form
<img width="568" alt="스크린샷 2024-02-19 오전 11 34 10" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/c9b98a78-79d9-4f77-9f49-be98c2d68834">

- [x] 댓글 form
<img width="570" alt="스크린샷 2024-02-19 오전 11 34 26" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/6de4d3db-3a8b-4800-9be4-757ae15774f0">

## 이슈 번호

close #43 