### PR TITLE
[FE] 이력서 상세 페이지에서 각 탭에 해당하는 목록 데이터 API 요청 로직 구현

### DIFF
--- a/src/apis/commentApi.ts
+++ b/src/apis/commentApi.ts
@@ -1,0 +1,50 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { REQUEST_URL } from '@constants';
+import { ApiResponse, PageNationData } from './response.types';
+import { Emoji } from './utilApi';
+
+export interface Comment {
+  id: number;
+  content: string;
+  commenterId: number;
+  commenterName: string;
+  commenterProfileUrl: string;
+  createdAt: string;
+  emojis: Emoji[];
+  myEmojiId: number;
+}
+
+type CommentList = Comment[];
+
+interface GetCommentList extends PageNationData {
+  comments: CommentList;
+}
+
+export const getCommentList = async ({ resumeId, pageParam }: { resumeId: number; pageParam: number }) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/comment?page=${pageParam}`);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetCommentList> = await response.json();
+
+  return data;
+};
+
+interface UseCommentListProps {
+  resumeId: number;
+}
+
+export const useCommentList = ({ resumeId }: UseCommentListProps) => {
+  return useInfiniteQuery({
+    queryKey: ['commentList', resumeId],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getCommentList({ resumeId, pageParam }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+  });
+};

--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -1,0 +1,54 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { REQUEST_URL } from '@constants';
+import { ApiResponse, PageNationData } from './response.types';
+import { Emoji } from './utilApi';
+
+// GET 피드백 목록 조회
+export interface Feedback {
+  id: number;
+  content: string;
+  commenterId: number;
+  commenterName: string;
+  commenterProfileUrl: string;
+  labelContent: string;
+  createdAt: string;
+  countOfReplies: number;
+  checked: boolean;
+  emojis: Emoji[];
+  myEmojiId: number;
+}
+
+type FeedbackList = Feedback[];
+
+interface GetFeedbackList extends PageNationData {
+  feedbacks: FeedbackList;
+}
+
+export const getFeedbackList = async ({ resumeId, pageParam }: { resumeId: number; pageParam: number }) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/feedback?page=${pageParam}`);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetFeedbackList> = await response.json();
+
+  return data;
+};
+
+interface UseFeedbackListProps {
+  resumeId: number;
+}
+
+export const useFeedbackList = ({ resumeId }: UseFeedbackListProps) => {
+  return useInfiniteQuery({
+    queryKey: ['feedbackList', resumeId],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getFeedbackList({ resumeId, pageParam }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+  });
+};

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -1,0 +1,54 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { REQUEST_URL } from '@constants';
+import { ApiResponse, PageNationData } from './response.types';
+import { Emoji } from './utilApi';
+
+export interface Question {
+  id: number;
+  content: string;
+  commenterId: number;
+  commenterName: string;
+  commenterProfileUrl: string;
+  labelContent: string;
+  createdAt: string;
+  countOfReplies: number;
+  bookmarked: boolean;
+  checked: boolean;
+  emojis: Emoji[];
+  myEmojiId: number;
+}
+
+type QuestionList = Question[];
+
+interface GetQuestionList extends PageNationData {
+  questions: QuestionList;
+}
+
+export const getQuestionList = async ({ resumeId, pageParam }: { resumeId: number; pageParam: number }) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question?page=${pageParam}`);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetQuestionList> = await response.json();
+
+  return data;
+};
+
+interface UseQuestionListProps {
+  resumeId: number;
+}
+
+export const useQuestionList = ({ resumeId }: UseQuestionListProps) => {
+  return useInfiniteQuery({
+    queryKey: ['questionList', resumeId],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getQuestionList({ resumeId, pageParam }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+  });
+};

--- a/src/mocks/data/questions.ts
+++ b/src/mocks/data/questions.ts
@@ -9,7 +9,7 @@ export const questions = Array.from({ length: 120 }, (_, idx) => {
     createdAt: '2024-01-27T15:43:09.752Z',
     countOfReplies: 10,
     bookmarked: true,
-    checked: true,
+    checked: false,
     emojis: [
       {
         id: 1,

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -6,6 +6,7 @@ import Comment from '@components/Comment';
 import PdfViewer from '@components/PdfViewer';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import { useFeedbackList } from '@apis/feedbackApi';
+import { useQuestionList } from '@apis/questionApi';
 import { useLabelList } from '@apis/utilApi';
 import { PDF_VIEWER_SCALE } from '@constants';
 import {
@@ -59,12 +60,17 @@ const ResumeDetail = () => {
   const { data: feedbackListData, fetchNextPage: fetchNextPageAboutFeedback } = useFeedbackList({
     resumeId: Number(resumeId),
   });
+  const { data: questionListData, fetchNextPage: fetchNextPageAboutQuestion } = useQuestionList({
+    resumeId: Number(resumeId),
+  });
 
   const feedbackList = feedbackListData?.pages.map((page) => page.feedbacks).flat();
+  const questionList = questionListData?.pages.map((page) => page.questions).flat();
 
   const { setTarget } = useIntersectionObserver({
     onIntersect: () => {
       if (currentTab === 'feedback') fetchNextPageAboutFeedback();
+      else if (currentTab === 'question') fetchNextPageAboutQuestion();
     },
     options: {
       threshold: 0.5,
@@ -201,6 +207,14 @@ const ResumeDetail = () => {
                         </Button>
                       </ReplyForm>
                     </ReplyList> */}
+                  </li>
+                );
+              })}
+            {currentTab === 'question' &&
+              questionList?.map((question) => {
+                return (
+                  <li key={question.id}>
+                    <Comment {...question} />
                   </li>
                 );
               })}

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -5,6 +5,7 @@ import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
 import PdfViewer from '@components/PdfViewer';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
+import { useCommentList } from '@apis/commentApi';
 import { useFeedbackList } from '@apis/feedbackApi';
 import { useQuestionList } from '@apis/questionApi';
 import { useLabelList } from '@apis/utilApi';
@@ -63,14 +64,19 @@ const ResumeDetail = () => {
   const { data: questionListData, fetchNextPage: fetchNextPageAboutQuestion } = useQuestionList({
     resumeId: Number(resumeId),
   });
+  const { data: commentListData, fetchNextPage: fetchNextPageAboutComment } = useCommentList({
+    resumeId: Number(resumeId),
+  });
 
   const feedbackList = feedbackListData?.pages.map((page) => page.feedbacks).flat();
   const questionList = questionListData?.pages.map((page) => page.questions).flat();
+  const commentList = commentListData?.pages.map((page) => page.comments).flat();
 
   const { setTarget } = useIntersectionObserver({
     onIntersect: () => {
       if (currentTab === 'feedback') fetchNextPageAboutFeedback();
       else if (currentTab === 'question') fetchNextPageAboutQuestion();
+      else if (currentTab === 'comment') fetchNextPageAboutComment();
     },
     options: {
       threshold: 0.5,
@@ -215,6 +221,14 @@ const ResumeDetail = () => {
                 return (
                   <li key={question.id}>
                     <Comment {...question} />
+                  </li>
+                );
+              })}
+            {currentTab === 'comment' &&
+              commentList?.map((comment) => {
+                return (
+                  <li key={comment.id}>
+                    <Comment {...comment} />
                   </li>
                 );
               })}

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -1,8 +1,11 @@
 import React, { MouseEvent, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { Button, Icon, Input, Label, Textarea } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
 import PdfViewer from '@components/PdfViewer';
+import useIntersectionObserver from '@hooks/useIntersectionObserver';
+import { useFeedbackList } from '@apis/feedbackApi';
 import { useLabelList } from '@apis/utilApi';
 import { PDF_VIEWER_SCALE } from '@constants';
 import {
@@ -51,6 +54,22 @@ const ResumeDetail = () => {
   const [comment, setComment] = useState<string>('');
 
   const { data: labelList } = useLabelList();
+
+  const resumeId = useParams();
+  const { data: feedbackListData, fetchNextPage: fetchNextPageAboutFeedback } = useFeedbackList({
+    resumeId: Number(resumeId),
+  });
+
+  const feedbackList = feedbackListData?.pages.map((page) => page.feedbacks).flat();
+
+  const { setTarget } = useIntersectionObserver({
+    onIntersect: () => {
+      if (currentTab === 'feedback') fetchNextPageAboutFeedback();
+    },
+    options: {
+      threshold: 0.5,
+    },
+  });
 
   const textareaPlaceholder = {
     feedback: '피드백',
@@ -150,80 +169,42 @@ const ResumeDetail = () => {
           </TabList>
 
           <CommentList>
-            <li>
-              <Comment
-                content="뭔가 이력서에 문제 해결과 관련된 내용이 부족한 것같아요."
-                commenterId={2}
-                commenterName="acceptor-gyu"
-                commenterProfileUrl="https://avatars.githubusercontent.com/u/71162390?v=4"
-                labelContent="자기소개"
-                createdAt="2023-12-22 15:46:05"
-                countOfReplies={0}
-                checked={false}
-                emojis={[
-                  {
-                    id: 2,
-                    count: 2,
-                  },
-                  {
-                    id: 3,
-                    count: 1,
-                  },
-                ]}
-                myEmojiId={2}
-              />
-              <ReplyList>
-                <Comment
-                  content="프로젝트에서 react-query를 사용하셨는데 사용한 이유가 궁금합니다."
-                  commenterId={1}
-                  writerId={1}
-                  commenterName="aken-you"
-                  commenterProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-                  createdAt="2024-01-24 16:19:37"
-                  emojis={[
-                    {
-                      id: 1,
-                      count: 10,
-                    },
-                    {
-                      id: 2,
-                      count: 3,
-                    },
-                  ]}
-                  myEmojiId={1}
-                />
-                <ReplyForm>
-                  <Textarea placeholder="댓글" />
-                  <Button variant="default" size="s">
-                    작성
-                  </Button>
-                </ReplyForm>
-              </ReplyList>
-            </li>
-
-            <li>
-              <Comment
-                content="뭔가 이력서에 문제 해결과 관련된 내용이 부족한 것같아요."
-                commenterId={2}
-                commenterName="acceptor-gyu"
-                commenterProfileUrl="https://avatars.githubusercontent.com/u/71162390?v=4"
-                labelContent="자기소개"
-                createdAt="2023-12-22 15:46:05"
-                countOfReplies={0}
-                checked={false}
-                emojis={[
-                  {
-                    id: 2,
-                    count: 2,
-                  },
-                  {
-                    id: 3,
-                    count: 1,
-                  },
-                ]}
-                myEmojiId={2}
-              />
-            </li>
+            {currentTab === 'feedback' &&
+              feedbackList?.map((feedback) => {
+                return (
+                  <li key={feedback.id}>
+                    <Comment {...feedback} />
+                    {/* <ReplyList>
+                      <Comment
+                        content="프로젝트에서 react-query를 사용하셨는데 사용한 이유가 궁금합니다."
+                        commenterId={1}
+                        writerId={1}
+                        commenterName="aken-you"
+                        commenterProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
+                        createdAt="2024-01-24 16:19:37"
+                        emojis={[
+                          {
+                            id: 1,
+                            count: 10,
+                          },
+                          {
+                            id: 2,
+                            count: 3,
+                          },
+                        ]}
+                        myEmojiId={1}
+                      />
+                      <ReplyForm>
+                        <Textarea placeholder="댓글" />
+                        <Button variant="default" size="s">
+                          작성
+                        </Button>
+                      </ReplyForm>
+                    </ReplyList> */}
+                  </li>
+                );
+              })}
+            <div ref={setTarget}></div>
           </CommentList>
 
           <Form>


### PR DESCRIPTION
## 개요

피드백, 예상질문, 댓글에 대한 목록 데이터를 요청하는 로직을 구현했다.

## 작업 사항

스크롤의 위치가 끝에 있을 경우 다음 페이지의 데이터를 요청하도록 했다. (무한스크롤)

- 피드백 목록
- 예상질문 목록
- 댓글 목록


## 이슈 번호

close #45 