### PR TITLE
[FE] 피드백, 예상질문, 댓글 form 데이터 제출 API 로직 구현

### DIFF
--- a/src/apis/commentApi.ts
+++ b/src/apis/commentApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 import { Emoji } from './utilApi';
@@ -47,4 +47,28 @@ export const useCommentList = ({ resumeId }: UseCommentListProps) => {
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
   });
+};
+
+// POST 댓글 추가
+export const postComment = async ({ resumeId, content }: { resumeId: number; content: string }) => {
+  const formData = new FormData();
+  formData.append('content', content);
+
+  // todo: request headers에 authorization 추가하기
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/comment`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data } = await response.json();
+
+  return data;
+};
+
+export const usePostComment = () => {
+  return useMutation({ mutationFn: postComment });
 };

--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 import { Emoji } from './utilApi';
@@ -51,4 +51,40 @@ export const useFeedbackList = ({ resumeId }: UseFeedbackListProps) => {
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
   });
+};
+
+// POST 피드백 작성
+export const postFeedback = async ({
+  resumeId,
+  content,
+  labelId,
+  resumePage,
+}: {
+  resumeId: number;
+  content: string;
+  labelId?: number;
+  resumePage: number;
+}) => {
+  const formData = new FormData();
+  formData.append('content', content);
+  formData.append('resumePage', String(resumePage));
+  if (labelId) formData.append('labelId', String(labelId));
+
+  // todo: request headers에 authorization 추가하기
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/feedback`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data } = await response.json();
+
+  return data;
+};
+
+export const usePostFeedback = () => {
+  return useMutation({ mutationFn: postFeedback });
 };

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 import { Emoji } from './utilApi';
@@ -51,4 +51,42 @@ export const useQuestionList = ({ resumeId }: UseQuestionListProps) => {
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
   });
+};
+
+// POST 예상 질문 추가
+export const postQuestion = async ({
+  resumeId,
+  content,
+  labelId,
+  labelContent,
+  resumePage,
+}: {
+  resumeId: number;
+  content: string;
+  labelId?: number;
+  labelContent?: string;
+  resumePage: number;
+}) => {
+  const formData = new FormData();
+  formData.append('content', content);
+  formData.append('resumePage', String(resumePage));
+  if (labelId) formData.append('labelId', String(labelId));
+  if (labelContent) formData.append('labelContent', labelContent);
+
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data } = await response.json();
+
+  return data;
+};
+
+export const usePostQuestion = () => {
+  return useMutation({ mutationFn: postQuestion });
 };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -134,6 +134,23 @@ export const handlers = [
       },
     });
   }),
+  http.post(`${REQUEST_URL.RESUME}/:resumeId/question`, async ({ request }) => {
+    const data = await request.formData();
+    const content = data.get('content');
+    const labelId = data.get('labelId');
+    const labelContent = data.get('labelContent');
+    const resumePage = data.get('resumePage');
+
+    // * headers에 authorization이 있는지 확인해야 하는데, 로그인 구현을 안했으므로 생략
+    // * labelContent가 이미 존재한다면, labelId 보내기
+    // * labelContent가 존재하지 않다면, labelContent 보내기
+    // * labelId, labelContent는 선택사항
+    if (!content || !resumePage) {
+      return new HttpResponse('Required data was not provided.', { status: 400 });
+    }
+
+    return new HttpResponse(null, { status: 201 });
+  }),
 
   // * util
   http.get(REQUEST_URL.LABEL, () => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -102,6 +102,20 @@ export const handlers = [
       },
     });
   }),
+  http.post(`${REQUEST_URL.RESUME}/:resumeId/feedback`, async ({ request }) => {
+    const data = await request.formData();
+    const content = data.get('content');
+    const labelId = data.get('labelId');
+    const resumePage = data.get('resumePage');
+
+    // * headers에 authorization이 있는지 확인해야 하는데, 로그인 구현을 안했으므로 생략
+    // * labelId는 선택사항
+    if (!content || !resumePage) {
+      return new HttpResponse('Required data was not provided.', { status: 400 });
+    }
+
+    return new HttpResponse(null, { status: 201 });
+  }),
 
   // * question
   http.get(`${REQUEST_URL.RESUME}/:resumeId/question`, ({ request }) => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -84,6 +84,16 @@ export const handlers = [
       },
     });
   }),
+  http.post(`${REQUEST_URL.RESUME}/:resumeId/comment`, async ({ request }) => {
+    const data = await request.formData();
+    const content = data.get('content');
+
+    if (!content) {
+      return new HttpResponse('Required data was not provided.', { status: 400 });
+    }
+
+    return new HttpResponse(null, { status: 201 });
+  }),
 
   // * feedback
   http.get(`${REQUEST_URL.RESUME}/:resumeId/feedback`, ({ request }) => {

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -58,7 +58,7 @@ const ResumeDetail = () => {
 
   const { data: labelList } = useLabelList();
 
-  const { id: resumeId } = useParams();
+  const { resumeId } = useParams();
   const { data: feedbackListData, fetchNextPage: fetchNextPageAboutFeedback } = useFeedbackList({
     resumeId: Number(resumeId),
   });

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -7,7 +7,7 @@ import PdfViewer from '@components/PdfViewer';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import { useCommentList } from '@apis/commentApi';
 import { useFeedbackList, usePostFeedback } from '@apis/feedbackApi';
-import { useQuestionList } from '@apis/questionApi';
+import { usePostQuestion, useQuestionList } from '@apis/questionApi';
 import { useLabelList } from '@apis/utilApi';
 import { PDF_VIEWER_SCALE } from '@constants';
 import {
@@ -85,6 +85,7 @@ const ResumeDetail = () => {
   });
 
   const { mutate: mutateAboutFeedback } = usePostFeedback();
+  const { mutate: mutateAboutQuestion } = usePostQuestion();
 
   const textareaPlaceholder = {
     feedback: '피드백',
@@ -95,6 +96,7 @@ const ResumeDetail = () => {
   const handleTabClick = (e: MouseEvent<HTMLButtonElement>, tab: ActiveTab) => {
     setCurrentTab(tab);
     setLabelContent('');
+    setLabelId(undefined);
     setComment('');
   };
 
@@ -108,6 +110,16 @@ const ResumeDetail = () => {
         resumeId: Number(resumeId),
         content: comment,
         labelId,
+        resumePage: currentPageNum,
+      });
+    } else if (currentTab === 'question') {
+      if (!comment) return;
+
+      mutateAboutQuestion({
+        resumeId: Number(resumeId),
+        content: comment,
+        labelId,
+        labelContent,
         resumePage: currentPageNum,
       });
     }

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -94,11 +94,15 @@ const ResumeDetail = () => {
     comment: '댓글',
   };
 
-  const handleTabClick = (e: MouseEvent<HTMLButtonElement>, tab: ActiveTab) => {
-    setCurrentTab(tab);
+  const resetForm = () => {
     setLabelContent('');
     setLabelId(undefined);
     setComment('');
+  };
+
+  const handleTabClick = (e: MouseEvent<HTMLButtonElement>, tab: ActiveTab) => {
+    setCurrentTab(tab);
+    resetForm();
   };
 
   const handleFormSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -131,6 +135,8 @@ const ResumeDetail = () => {
         content: comment,
       });
     }
+
+    resetForm();
   };
 
   return (
@@ -294,7 +300,11 @@ const ResumeDetail = () => {
             {currentTab === 'question' && (
               <>
                 <KeywordLabel>{labelContent}</KeywordLabel>
-                <Input placeholder="예상질문 키워드" onChange={(e) => setLabelContent(e.target.value)} />
+                <Input
+                  placeholder="예상질문 키워드"
+                  value={labelContent}
+                  onChange={(e) => setLabelContent(e.target.value)}
+                />
               </>
             )}
             <FormContent>

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -5,7 +5,7 @@ import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
 import PdfViewer from '@components/PdfViewer';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
-import { useCommentList } from '@apis/commentApi';
+import { useCommentList, usePostComment } from '@apis/commentApi';
 import { useFeedbackList, usePostFeedback } from '@apis/feedbackApi';
 import { usePostQuestion, useQuestionList } from '@apis/questionApi';
 import { useLabelList } from '@apis/utilApi';
@@ -86,6 +86,7 @@ const ResumeDetail = () => {
 
   const { mutate: mutateAboutFeedback } = usePostFeedback();
   const { mutate: mutateAboutQuestion } = usePostQuestion();
+  const { mutate: mutateAboutComment } = usePostComment();
 
   const textareaPlaceholder = {
     feedback: '피드백',
@@ -121,6 +122,13 @@ const ResumeDetail = () => {
         labelId,
         labelContent,
         resumePage: currentPageNum,
+      });
+    } else if (currentTab === 'comment') {
+      if (!comment) return;
+
+      mutateAboutComment({
+        resumeId: Number(resumeId),
+        content: comment,
       });
     }
   };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -18,7 +18,7 @@ const router = createBrowserRouter([
       { index: true, element: <MainPage /> },
       { path: ROUTE_PATH.MY_PAGE, element: <MyPage /> },
       { path: ROUTE_PATH.RESUME, element: <Resume /> },
-      { path: `${ROUTE_PATH.RESUME}/:id`, element: <ResumeDetail /> },
+      { path: `${ROUTE_PATH.RESUME}/:resumeId`, element: <ResumeDetail /> },
       { path: ROUTE_PATH.MY_RESUME, element: <MyResume /> },
       { path: ROUTE_PATH.RESUME_UPLOAD, element: <ResumeUpload /> },
     ],


### PR DESCRIPTION
## 개요

이력서 상세 페이지에 있는 피드백, 예상질문, 댓글 form 데이터를 post 요청보내는 로직을 구현했다.

## 작업 사항

- 피드백 form 데이터 post 요청
- 예상질문 form 데이터 post 요청
- 댓글 form 데이터 post 요청

## 문제

예상질문에서 입력한 키워드가 이미 존재하다면 id 값을, 존재하지 않다면 키워드 값 자체를 form 데이터에 저장하는 기능을 구현하지 못했다.

## 이슈 번호

close #47 