### PR TITLE
[FE] 이력서 상세 정보 조회 API 로직 구현

### DIFF
--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 
@@ -44,6 +44,32 @@ export const useResumeList = () => {
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
   });
+};
+
+// GET 이력서 상세 조회
+interface GetResumeDetail {
+  resumeUrl: string;
+  title: string;
+  writerName: string;
+  writerProfileUrl: string;
+  occupation: string;
+  year: number;
+}
+
+export const getResumeDetail = async (resumeId: number) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}`);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetResumeDetail> = await response.json();
+
+  return data;
+};
+
+export const useResumeDetail = (resumeId: number) => {
+  return useQuery({ queryKey: ['resume', resumeId], queryFn: () => getResumeDetail(resumeId) });
 };
 
 // POST 이력서 업로드

--- a/src/components/PdfViewer/index.tsx
+++ b/src/components/PdfViewer/index.tsx
@@ -30,7 +30,10 @@ const PdfViewer = ({
   return (
     <PDFViewerLayout $width={width} $height={height}>
       <PDFViewerContainer>
-        <Document file={file} onLoadSuccess={({ numPages }) => onLoadSuccess(numPages)}>
+        <Document
+          file={typeof file === 'string' ? `${process.env.BASE_PDF_URL}/${file}` : file}
+          onLoadSuccess={({ numPages }) => onLoadSuccess(numPages)}
+        >
           {showAllPages ? (
             Array.from(new Array(numPages), (el, index) => (
               <Page

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -8,6 +8,7 @@ import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import { useCommentList, usePostComment } from '@apis/commentApi';
 import { useFeedbackList, usePostFeedback } from '@apis/feedbackApi';
 import { usePostQuestion, useQuestionList } from '@apis/questionApi';
+import { useResumeDetail } from '@apis/resumeApi';
 import { useLabelList } from '@apis/utilApi';
 import { PDF_VIEWER_SCALE } from '@constants';
 import {
@@ -42,6 +43,10 @@ const ResumeDetail = () => {
   const INIT_CURRENT_PAGE_NUM = 1;
   const { INIT_SCALE, MAX_SCALE, MIN_SCALE, SCALE_STEP } = PDF_VIEWER_SCALE;
 
+  const { resumeId } = useParams();
+
+  const { data: resumeDetail } = useResumeDetail(Number(resumeId));
+
   const [file, setFile] = useState<string | undefined>(
     `${process.env.BASE_PDF_URL}/ad6c62c6이력서_샘플.pdf`,
   );
@@ -58,7 +63,6 @@ const ResumeDetail = () => {
 
   const { data: labelList } = useLabelList();
 
-  const { resumeId } = useParams();
   const { data: feedbackListData, fetchNextPage: fetchNextPageAboutFeedback } = useFeedbackList({
     resumeId: Number(resumeId),
   });
@@ -145,13 +149,15 @@ const ResumeDetail = () => {
         <ResumeViewer>
           <ResumeViewerHeader>
             <ResumeInfo>
-              <Title>네이버 신입 프론트 공채 준비</Title>
+              <Title>{resumeDetail?.title}</Title>
 
               <WriterInfoContainer>
-                <WriterImg />
+                <WriterImg src={resumeDetail?.writerProfileUrl} />
                 <WriterInfo>
-                  <span>aken-you</span>
-                  <Career>Frontend | 신입</Career>
+                  <span>{resumeDetail?.writerName}</span>
+                  <Career>
+                    {resumeDetail?.occupation} | {resumeDetail?.year === 0 ? '신입' : resumeDetail?.year}
+                  </Career>
                 </WriterInfo>
               </WriterInfoContainer>
             </ResumeInfo>
@@ -200,7 +206,7 @@ const ResumeDetail = () => {
             </PdfViewerInfo>
             <PdfViewer
               showAllPages={false}
-              file={file}
+              file={resumeDetail?.resumeUrl}
               numPages={numPages}
               scale={scale}
               pageNum={currentPageNum}


### PR DESCRIPTION
## 개요

이력서 상세 정보를 get 요청을 보내는 로직을 구현했다.

## 작업 사항

- PdfViewer에서 file prop의 type이 string일 경우 앞에 pdf base url 추가
- 이력서 상세 정보 조회 요청을 보내는 커스텀 훅 생성
- 이력서 상세 페이지에서 이력서 상세 정보 조회

## 이슈 번호

close #50 