### PR TITLE
[FE] authorization code POST 요청 시 fetch에 credentials 속성 추가

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -13,6 +13,7 @@ const postAuthorizationCode = async (code: string) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ code }),
+    credentials: 'include',
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## 개요

authorization code POST 요청 시 fetch에 credentials 속성 추가했다.

## 작업 사항

- `credentials: 'include'`로 설정

## 이슈 번호

#54 
