### PR TITLE
[FE] jwt가 user context에 저장되지 않는 문제 해결

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -1,4 +1,6 @@
+import { useNavigate } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
+import { useUserContext } from '@contexts/userContext';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse } from './response.types';
 
@@ -26,7 +28,14 @@ const postAuthorizationCode = async (code: string) => {
 };
 
 export const usePostAuthorizationCode = () => {
+  const navigate = useNavigate();
+  const { login } = useUserContext();
+
   return useMutation({
     mutationFn: postAuthorizationCode,
+    onSuccess: ({ jwt }) => {
+      login(jwt);
+      navigate('/');
+    },
   });
 };

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,13 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 const MainPage = () => {
-  // * test용
-  useEffect(() => {
-    fetch(`https://api.review-me.co.kr/test`)
-      .then((res) => res.json())
-      .then((data) => console.log(data));
-  }, []);
-
   return <div>MainPage</div>;
 };
 

--- a/src/pages/SocialLogin/index.tsx
+++ b/src/pages/SocialLogin/index.tsx
@@ -1,22 +1,13 @@
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useUserContext } from '@contexts/userContext';
 import { usePostAuthorizationCode } from '@apis/login';
 
 const SocialLogin = () => {
-  const navigate = useNavigate();
   const code = new URLSearchParams(window.location.search).get('code');
-  const { mutate, data } = usePostAuthorizationCode();
-  const { login } = useUserContext();
+  const { mutate } = usePostAuthorizationCode();
 
   useEffect(() => {
     if (code) {
       mutate(code);
-      // todo: 이전 페이지로 이동 (현재는 메인 페이지로 이동하도록 구현)
-      navigate('/');
-      if (data?.jwt) {
-        login(data.jwt);
-      }
     }
   }, []);
 


### PR DESCRIPTION
## 개요

`useMutation`의 `onSuccess`를 이용하여 jwt가 응답이 온 다음, user context에 jwt를 저장하고 메인페이지로 이동하도록 구현했다.

## 작업 사항

- `usePostAuthorizationCode`에서 `useMutation`에 `onSuccess` 추가

## 이슈 번호

close #61 