### PR TITLE
[FE] 피드백, 예상질문, 댓글 API 로직에서 parameter에 resumePage 추가 및 Emoji type 수정

### DIFF
--- a/src/apis/commentApi.ts
+++ b/src/apis/commentApi.ts
@@ -1,7 +1,11 @@
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
-import { Emoji } from './utilApi';
+
+interface Emoji {
+  id: number;
+  count: number;
+}
 
 export interface Comment {
   id: number;
@@ -20,8 +24,18 @@ interface GetCommentList extends PageNationData {
   comments: CommentList;
 }
 
-export const getCommentList = async ({ resumeId, pageParam }: { resumeId: number; pageParam: number }) => {
-  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/comment?page=${pageParam}`);
+export const getCommentList = async ({
+  resumeId,
+  pageParam,
+  resumePage,
+}: {
+  resumeId: number;
+  pageParam: number;
+  resumePage: number;
+}) => {
+  const response = await fetch(
+    `${REQUEST_URL.RESUME}/${resumeId}/comment?page=${pageParam}&resumePage=${resumePage}`,
+  );
 
   if (!response.ok) {
     throw response;
@@ -34,13 +48,14 @@ export const getCommentList = async ({ resumeId, pageParam }: { resumeId: number
 
 interface UseCommentListProps {
   resumeId: number;
+  resumePage: number;
 }
 
-export const useCommentList = ({ resumeId }: UseCommentListProps) => {
+export const useCommentList = ({ resumeId, resumePage }: UseCommentListProps) => {
   return useInfiniteQuery({
     queryKey: ['commentList', resumeId],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getCommentList({ resumeId, pageParam }),
+    queryFn: ({ pageParam }) => getCommentList({ resumeId, pageParam, resumePage }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -1,9 +1,13 @@
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
-import { Emoji } from './utilApi';
 
 // GET 피드백 목록 조회
+interface Emoji {
+  id: number;
+  count: number;
+}
+
 export interface Feedback {
   id: number;
   content: string;
@@ -24,8 +28,18 @@ interface GetFeedbackList extends PageNationData {
   feedbacks: FeedbackList;
 }
 
-export const getFeedbackList = async ({ resumeId, pageParam }: { resumeId: number; pageParam: number }) => {
-  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/feedback?page=${pageParam}`);
+export const getFeedbackList = async ({
+  resumeId,
+  pageParam,
+  resumePage,
+}: {
+  resumeId: number;
+  pageParam: number;
+  resumePage: number;
+}) => {
+  const response = await fetch(
+    `${REQUEST_URL.RESUME}/${resumeId}/feedback?page=${pageParam}&resumePage=${resumePage}`,
+  );
 
   if (!response.ok) {
     throw response;
@@ -38,13 +52,14 @@ export const getFeedbackList = async ({ resumeId, pageParam }: { resumeId: numbe
 
 interface UseFeedbackListProps {
   resumeId: number;
+  resumePage: number;
 }
 
-export const useFeedbackList = ({ resumeId }: UseFeedbackListProps) => {
+export const useFeedbackList = ({ resumeId, resumePage }: UseFeedbackListProps) => {
   return useInfiniteQuery({
     queryKey: ['feedbackList', resumeId],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getFeedbackList({ resumeId, pageParam }),
+    queryFn: ({ pageParam }) => getFeedbackList({ resumeId, pageParam, resumePage }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -1,7 +1,11 @@
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
-import { Emoji } from './utilApi';
+
+interface Emoji {
+  id: number;
+  count: number;
+}
 
 export interface Question {
   id: number;
@@ -24,8 +28,18 @@ interface GetQuestionList extends PageNationData {
   questions: QuestionList;
 }
 
-export const getQuestionList = async ({ resumeId, pageParam }: { resumeId: number; pageParam: number }) => {
-  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question?page=${pageParam}`);
+export const getQuestionList = async ({
+  resumeId,
+  pageParam,
+  resumePage,
+}: {
+  resumeId: number;
+  pageParam: number;
+  resumePage: number;
+}) => {
+  const response = await fetch(
+    `${REQUEST_URL.RESUME}/${resumeId}/question?page=${pageParam}&resumePage=${resumePage}`,
+  );
 
   if (!response.ok) {
     throw response;
@@ -38,13 +52,14 @@ export const getQuestionList = async ({ resumeId, pageParam }: { resumeId: numbe
 
 interface UseQuestionListProps {
   resumeId: number;
+  resumePage: number;
 }
 
-export const useQuestionList = ({ resumeId }: UseQuestionListProps) => {
+export const useQuestionList = ({ resumeId, resumePage }: UseQuestionListProps) => {
   return useInfiniteQuery({
     queryKey: ['questionList', resumeId],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getQuestionList({ resumeId, pageParam }),
+    queryFn: ({ pageParam }) => getQuestionList({ resumeId, pageParam, resumePage }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/apis/utilApi.ts
+++ b/src/apis/utilApi.ts
@@ -59,9 +59,9 @@ export const useScopeList = () => {
 };
 
 // GET 이모지 목록 조회
-export interface Emoji {
+interface Emoji {
   id: number;
-  count: number;
+  emoji: string;
 }
 
 interface GetEmojiList {

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -57,12 +57,15 @@ const ResumeDetail = () => {
 
   const { data: feedbackListData, fetchNextPage: fetchNextPageAboutFeedback } = useFeedbackList({
     resumeId: Number(resumeId),
+    resumePage: currentPageNum,
   });
   const { data: questionListData, fetchNextPage: fetchNextPageAboutQuestion } = useQuestionList({
     resumeId: Number(resumeId),
+    resumePage: currentPageNum,
   });
   const { data: commentListData, fetchNextPage: fetchNextPageAboutComment } = useCommentList({
     resumeId: Number(resumeId),
+    resumePage: currentPageNum,
   });
 
   const feedbackList = feedbackListData?.pages.map((page) => page.feedbacks).flat();


### PR DESCRIPTION
## 개요

피드백, 예상질문, 댓글 API 로직을 수정하였다.

## 작업 사항

- 피드백 request url의 parameter에 resumePage 추가
- 예상질문 request url의 parameter에 resumePage 추가
- 댓글 request url의 parameter에 resumePage 추가
- 피드백, 예상질문, 댓글 data의 type에서 사용하던 Emoji type 수정
- 이모지 목록 데이터 type 수정

## 이슈 번호

close #63 