### PR TITLE
[FE] 피드백, 예상질문, 댓글에 관한 query 수정

### DIFF
--- a/src/apis/commentApi.ts
+++ b/src/apis/commentApi.ts
@@ -15,7 +15,7 @@ export interface Comment {
   commenterProfileUrl: string;
   createdAt: string;
   emojis: Emoji[];
-  myEmojiId: number;
+  myEmojiId: number | null;
 }
 
 type CommentList = Comment[];
@@ -24,18 +24,8 @@ interface GetCommentList extends PageNationData {
   comments: CommentList;
 }
 
-export const getCommentList = async ({
-  resumeId,
-  pageParam,
-  resumePage,
-}: {
-  resumeId: number;
-  pageParam: number;
-  resumePage: number;
-}) => {
-  const response = await fetch(
-    `${REQUEST_URL.RESUME}/${resumeId}/comment?page=${pageParam}&resumePage=${resumePage}`,
-  );
+export const getCommentList = async ({ resumeId, pageParam }: { resumeId: number; pageParam: number }) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/comment?page=${pageParam}`);
 
   if (!response.ok) {
     throw response;
@@ -48,19 +38,20 @@ export const getCommentList = async ({
 
 interface UseCommentListProps {
   resumeId: number;
-  resumePage: number;
+  enabled: boolean;
 }
 
-export const useCommentList = ({ resumeId, resumePage }: UseCommentListProps) => {
+export const useCommentList = ({ resumeId, enabled }: UseCommentListProps) => {
   return useInfiniteQuery({
     queryKey: ['commentList', resumeId],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getCommentList({ resumeId, pageParam, resumePage }),
+    queryFn: ({ pageParam }) => getCommentList({ resumeId, pageParam }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
+    enabled,
   });
 };
 

--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -19,7 +19,7 @@ export interface Feedback {
   countOfReplies: number;
   checked: boolean;
   emojis: Emoji[];
-  myEmojiId: number;
+  myEmojiId: number | null;
 }
 
 type FeedbackList = Feedback[];
@@ -53,9 +53,10 @@ export const getFeedbackList = async ({
 interface UseFeedbackListProps {
   resumeId: number;
   resumePage: number;
+  enabled: boolean;
 }
 
-export const useFeedbackList = ({ resumeId, resumePage }: UseFeedbackListProps) => {
+export const useFeedbackList = ({ resumeId, resumePage, enabled }: UseFeedbackListProps) => {
   return useInfiniteQuery({
     queryKey: ['feedbackList', resumeId],
     initialPageParam: 0,
@@ -65,6 +66,7 @@ export const useFeedbackList = ({ resumeId, resumePage }: UseFeedbackListProps) 
 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
+    enabled,
   });
 };
 

--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -58,7 +58,7 @@ interface UseFeedbackListProps {
 
 export const useFeedbackList = ({ resumeId, resumePage, enabled }: UseFeedbackListProps) => {
   return useInfiniteQuery({
-    queryKey: ['feedbackList', resumeId],
+    queryKey: ['feedbackList', resumeId, resumePage],
     initialPageParam: 0,
     queryFn: ({ pageParam }) => getFeedbackList({ resumeId, pageParam, resumePage }),
     getNextPageParam: (lastPage) => {

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -16,10 +16,10 @@ export interface Question {
   labelContent: string;
   createdAt: string;
   countOfReplies: number;
-  bookmarked: boolean;
+  bookmarked?: boolean;
   checked: boolean;
   emojis: Emoji[];
-  myEmojiId: number;
+  myEmojiId: number | null;
 }
 
 type QuestionList = Question[];
@@ -53,9 +53,10 @@ export const getQuestionList = async ({
 interface UseQuestionListProps {
   resumeId: number;
   resumePage: number;
+  enabled: boolean;
 }
 
-export const useQuestionList = ({ resumeId, resumePage }: UseQuestionListProps) => {
+export const useQuestionList = ({ resumeId, resumePage, enabled }: UseQuestionListProps) => {
   return useInfiniteQuery({
     queryKey: ['questionList', resumeId],
     initialPageParam: 0,
@@ -65,6 +66,7 @@ export const useQuestionList = ({ resumeId, resumePage }: UseQuestionListProps) 
 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
+    enabled,
   });
 };
 

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -58,7 +58,7 @@ interface UseQuestionListProps {
 
 export const useQuestionList = ({ resumeId, resumePage, enabled }: UseQuestionListProps) => {
   return useInfiniteQuery({
-    queryKey: ['questionList', resumeId],
+    queryKey: ['questionList', resumeId, resumePage],
     initialPageParam: 0,
     queryFn: ({ pageParam }) => getQuestionList({ resumeId, pageParam, resumePage }),
     getNextPageParam: (lastPage) => {

--- a/src/mocks/data/feedbacks.ts
+++ b/src/mocks/data/feedbacks.ts
@@ -1,4 +1,6 @@
-export const feedbacks = Array.from({ length: 120 }, (_, idx) => {
+import { Feedback } from '@apis/feedbackApi';
+
+const firstResumePageFeedbacks: Feedback[] = Array.from({ length: 20 }, (_, idx) => {
   return {
     id: idx + 1,
     content: '뭔가 이력서에 문제 해결과 관련된 내용이 부족한 것같아요.',
@@ -11,14 +13,109 @@ export const feedbacks = Array.from({ length: 120 }, (_, idx) => {
     checked: false,
     emojis: [
       {
+        id: 1,
+        count: 1,
+      },
+      {
         id: 2,
-        count: 2,
+        count: 1,
       },
       {
         id: 3,
-        count: 1,
+        count: 0,
+      },
+      {
+        id: 4,
+        count: 0,
+      },
+      {
+        id: 5,
+        count: 0,
       },
     ],
     myEmojiId: 2,
   };
 });
+
+const secondResumePageFeedbacks: Feedback[] = Array.from({ length: 20 }, (_, idx) => {
+  return {
+    id: idx + 21,
+    content: '협업과 관련된 내용이 추가되었으면 좋겠어요',
+    commenterId: 2,
+    commenterName: 'acceptor-gyu',
+    commenterProfileUrl: 'https://avatars.githubusercontent.com/u/71162390?v=4',
+    labelContent: '협업',
+    createdAt: '2024-02-21 14:56:21',
+    countOfReplies: 0,
+    checked: false,
+    emojis: [
+      {
+        id: 1,
+        count: 1,
+      },
+      {
+        id: 2,
+        count: 0,
+      },
+      {
+        id: 3,
+        count: 0,
+      },
+      {
+        id: 4,
+        count: 0,
+      },
+      {
+        id: 5,
+        count: 0,
+      },
+    ],
+    myEmojiId: null,
+  };
+});
+
+const thirdResumePageFeedbacks: Feedback[] = Array.from({ length: 20 }, (_, idx) => {
+  return {
+    id: idx + 41,
+    content: '문제 해결 과정이 잘 드러나지 않은 것 같습니다',
+    commenterId: 2,
+    commenterName: 'acceptor-gyu',
+    commenterProfileUrl: 'https://avatars.githubusercontent.com/u/71162390?v=4',
+    labelContent: '',
+    createdAt: '2024-02-21 14:56:21',
+    countOfReplies: 0,
+    checked: false,
+    emojis: [
+      {
+        id: 1,
+        count: 0,
+      },
+      {
+        id: 2,
+        count: 0,
+      },
+      {
+        id: 3,
+        count: 0,
+      },
+      {
+        id: 4,
+        count: 0,
+      },
+      {
+        id: 5,
+        count: 1,
+      },
+    ],
+    myEmojiId: null,
+  };
+});
+
+const fourthResumePageFeedbacks: Feedback[] = [];
+
+export const feedbacks: Record<string, Feedback[]> = {
+  1: firstResumePageFeedbacks,
+  2: secondResumePageFeedbacks,
+  3: thirdResumePageFeedbacks,
+  4: fourthResumePageFeedbacks,
+};

--- a/src/mocks/data/questions.ts
+++ b/src/mocks/data/questions.ts
@@ -1,4 +1,6 @@
-export const questions = Array.from({ length: 120 }, (_, idx) => {
+import { Question } from '@apis/questionApi';
+
+const firstResumePageQuestions: Question[] = Array.from({ length: 20 }, (_, idx) => {
   return {
     id: idx + 1,
     content: '프로젝트에서 react-query를 사용하셨는데 사용한 이유가 궁금합니다.',
@@ -8,7 +10,6 @@ export const questions = Array.from({ length: 120 }, (_, idx) => {
     labelContent: 'react-query',
     createdAt: '2024-01-27T15:43:09.752Z',
     countOfReplies: 10,
-    bookmarked: true,
     checked: false,
     emojis: [
       {
@@ -19,3 +20,35 @@ export const questions = Array.from({ length: 120 }, (_, idx) => {
     myEmojiId: 1,
   };
 });
+
+const secondResumePageQuestions: Question[] = Array.from({ length: 20 }, (_, idx) => {
+  return {
+    id: idx + 21,
+    content: '팀원과 협업 중 의견 충돌이 생겼을 때 어떻게 해결하셨나요?',
+    commenterId: 1,
+    commenterName: 'aken-you',
+    commenterProfileUrl: 'https://avatars.githubusercontent.com/u/96980857?v=4',
+    labelContent: 'react-query',
+    createdAt: '2024-01-27T15:43:09.752Z',
+    countOfReplies: 10,
+    checked: false,
+    emojis: [
+      {
+        id: 1,
+        count: 10,
+      },
+    ],
+    myEmojiId: 1,
+  };
+});
+
+const thirdResumePageQuestions: Question[] = [];
+
+const fourthResumePageQuestions: Question[] = [];
+
+export const questions: Record<string, Question[]> = {
+  1: firstResumePageQuestions,
+  2: secondResumePageQuestions,
+  3: thirdResumePageQuestions,
+  4: fourthResumePageQuestions,
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -73,7 +73,7 @@ export const handlers = [
     const pageNumber = Number(url.searchParams.get('page') || 0);
     const pageSize = Number(url.searchParams.get('size') || 10);
     const totalCount = comments.length;
-    const lastPage = Math.ceil(totalCount / pageSize);
+    const lastPage = Math.ceil(totalCount / pageSize) - 1;
 
     return HttpResponse.json({
       data: {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -100,12 +100,22 @@ export const handlers = [
     const url = new URL(request.url);
     const pageNumber = Number(url.searchParams.get('page') || 0);
     const pageSize = Number(url.searchParams.get('size') || 10);
-    const totalCount = feedbacks.length;
-    const lastPage = Math.ceil(totalCount / pageSize);
+    const resumePage = url.searchParams.get('resumePage');
+
+    if (!resumePage) {
+      return new HttpResponse('Required data was not provided.', { status: 400 });
+    }
+
+    const totalCount = feedbacks[resumePage].length;
+    const lastPage = Math.ceil(totalCount / pageSize) - 1;
+
+    if (pageNumber > lastPage) {
+      return new HttpResponse('The provided page number is out of range.', { status: 400 });
+    }
 
     return HttpResponse.json({
       data: {
-        feedbacks: feedbacks.slice(pageNumber * pageSize, (pageNumber + 1) * pageSize),
+        feedbacks: feedbacks[resumePage].slice(pageNumber * pageSize, (pageNumber + 1) * pageSize),
         pageNumber,
         lastPage,
         pageSize,
@@ -131,13 +141,23 @@ export const handlers = [
   http.get(`${REQUEST_URL.RESUME}/:resumeId/question`, ({ request }) => {
     const url = new URL(request.url);
     const pageNumber = Number(url.searchParams.get('page') || 0);
-    const pageSize = 10;
-    const totalCount = questions.length;
-    const lastPage = Math.ceil(totalCount / pageSize);
+    const pageSize = Number(url.searchParams.get('size') || 10);
+    const resumePage = url.searchParams.get('resumePage');
+
+    if (!resumePage) {
+      return new HttpResponse('Required data was not provided.', { status: 400 });
+    }
+
+    const totalCount = questions[resumePage].length;
+    const lastPage = Math.ceil(totalCount / pageSize) - 1;
+
+    if (pageNumber > lastPage) {
+      return new HttpResponse('The provided page number is out of range.', { status: 400 });
+    }
 
     return HttpResponse.json({
       data: {
-        questions: questions.slice(pageNumber * pageSize, (pageNumber + 1) * pageSize),
+        questions: questions[resumePage].slice(pageNumber * pageSize, (pageNumber + 1) * pageSize),
         pageNumber,
         lastPage,
         pageSize,

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -55,17 +55,20 @@ const ResumeDetail = () => {
 
   const { data: labelList } = useLabelList();
 
+  // todo: tab 변경 시 변경된 tab에 해당하는 currentPageNum을 가져오기
   const { data: feedbackListData, fetchNextPage: fetchNextPageAboutFeedback } = useFeedbackList({
     resumeId: Number(resumeId),
     resumePage: currentPageNum,
+    enabled: currentTab === 'feedback',
   });
   const { data: questionListData, fetchNextPage: fetchNextPageAboutQuestion } = useQuestionList({
     resumeId: Number(resumeId),
     resumePage: currentPageNum,
+    enabled: currentTab === 'question',
   });
   const { data: commentListData, fetchNextPage: fetchNextPageAboutComment } = useCommentList({
     resumeId: Number(resumeId),
-    resumePage: currentPageNum,
+    enabled: currentTab === 'comment',
   });
 
   const feedbackList = feedbackListData?.pages.map((page) => page.feedbacks).flat();


### PR DESCRIPTION
## 개요

각각의 피드백, 예상질문, 댓글 목록 데이터를 요청하는 useInfiniteQuery를 수정했다.
또한 msw에서 피드백, 예상질문에 관한 로직을 수정하였다.

## 작업 사항

- 각각의 피드백, 예상질문, 댓글 목록 데이터를 요청하는 `useInfiniteQuery`에 enabled 설정
  - 현재 탭에 해당되는 목록을 보여주기 위해 설정 
- 피드백 목록을 요청하는 useInfiniteQuery의 queryKey에 `resumePage` 추가
  - 현재 사용자가 보고있는 pdf 파일의 페이지가 바뀌면 데이터도 변경되어야 하기 때문에 추가
- 예상질문 목록을 요청하는 useInfiniteQuery의 queryKey에 `resumePage` 추가
  - 현재 사용자가 보고있는 pdf 파일의 페이지가 바뀌면 데이터도 변경되어야 하기 때문에 추가
- 피드백 목록 mock 데이터 수정
  - resumePage에 따라 다른 데이터 제공 
- 예상질문 목록 mock 데이터 수정
  - resumePage에 따라 다른 데이터 제공 
- msw에서 피드백 목록 조회 handler와 예상질문 목록 조회 handler 수정
  - 두 handler 모두 resumePage 파라미터 적용

## 이슈 번호

close #65 