### PR TITLE
[FE] 이력서 수정 페이지 구현

### DIFF
--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -115,3 +115,35 @@ export const postResume = async ({
 export const usePostResume = () => {
   return useMutation({ mutationFn: postResume });
 };
+
+// PATCH 이력서 수정
+export const updateResume = async ({
+  resumeId,
+  title,
+  scopeId,
+  occupationId,
+  year,
+}: {
+  resumeId: number;
+  title: string;
+  scopeId: number;
+  occupationId: number;
+  year: number;
+}) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ title, scopeId, occupationId, year }),
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const useUpdateResume = () => {
+  return useMutation({ mutationFn: updateResume });
+};

--- a/src/components/MyResumeItem/index.tsx
+++ b/src/components/MyResumeItem/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useModal } from 'review-me-design-system';
 import ResumeDeleteModal from '@components/Modal/ResumeDeleteModal';
+import { ROUTE_PATH } from '@constants';
 import { formatDate } from '@utils';
 import {
   Button,
@@ -22,6 +24,7 @@ interface Props {
 
 const MyResumeItem = ({ id, title, year, occupation, scope, createdAt }: Props) => {
   const { isOpen: isOpenDeleteModal, open: openDeleteModal, close: closeDeleteModal } = useModal();
+  const navigate = useNavigate();
 
   return (
     <MyResumeItemLayout>
@@ -33,7 +36,14 @@ const MyResumeItem = ({ id, title, year, occupation, scope, createdAt }: Props) 
         <span>{formatDate(createdAt)}</span>
       </DescriptionContainer>
       <ButtonsContainer>
-        <Button $position="left">수정</Button>
+        <Button
+          $position="left"
+          onClick={() => {
+            navigate(ROUTE_PATH.RESUME_UPDATE, { state: { resumeId: id, title, year, occupation, scope } });
+          }}
+        >
+          수정
+        </Button>
         <Button $position="right" onClick={openDeleteModal}>
           삭제
         </Button>

--- a/src/components/ResumeForm/ResumeUpdateForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUpdateForm/index.tsx
@@ -1,0 +1,163 @@
+import React, { FormEvent } from 'react';
+import { Button, Icon, Input, Select } from 'review-me-design-system';
+import ButtonGroup from '@components/ButtonGroup';
+import PdfViewer from '@components/PdfViewer';
+import useMediaQuery from '@hooks/useMediaQuery';
+import usePdf from '@hooks/usePdf';
+import { Occupation, Scope, useOccupationList, useScopeList } from '@apis/utilApi';
+import { Field, FieldContainer, Form, ResumeFormLayout, Label } from '../style';
+
+interface Props {
+  resumeId: number;
+  file?: string;
+  title: string;
+  year?: number;
+  selectedOccupation?: Occupation;
+  selectedScope?: Scope;
+  onChangeTitle: (title: string) => void;
+  onChangeYear: (year: number) => void;
+  onChangeSelectedOccupation: (occupation: Occupation) => void;
+  onChangeSelectedScope: (scope: Scope) => void;
+  onSubmit: ({
+    resumeId,
+    title,
+    scopeId,
+    occupationId,
+    year,
+  }: {
+    resumeId: number;
+    title: string;
+    scopeId: number;
+    occupationId: number;
+    year: number;
+  }) => void;
+}
+
+const ResumeUpdateForm = ({
+  resumeId,
+  file,
+  title,
+  year,
+  selectedOccupation,
+  selectedScope,
+  onChangeTitle,
+  onChangeYear,
+  onChangeSelectedOccupation,
+  onChangeSelectedScope,
+  onSubmit,
+}: Props) => {
+  const PDF_BUTTON_ICON_SIZE = 24;
+
+  const { totalPages, scale, zoomIn, zoomOut, setTotalPages } = usePdf({});
+  const { matches: isMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 768px)' });
+
+  const { data: occupationList } = useOccupationList();
+  const { data: scopeList } = useScopeList();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!selectedOccupation || !selectedScope || title.length === 0 || !year) return;
+
+    onSubmit({
+      resumeId,
+      title,
+      scopeId: selectedScope.id,
+      occupationId: selectedOccupation.id,
+      year,
+    });
+  };
+
+  return (
+    <ResumeFormLayout>
+      <PdfViewer
+        showAllPages={true}
+        file={file}
+        totalPages={totalPages}
+        scale={scale}
+        onLoadSuccess={setTotalPages}
+        width={isMDevice ? '100%' : '55%'}
+        height="35rem"
+      >
+        <ButtonGroup height="2rem">
+          <ButtonGroup.Button onClick={zoomIn}>
+            <Icon iconName="plus" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
+          </ButtonGroup.Button>
+          <ButtonGroup.Button onClick={zoomOut}>
+            <Icon iconName="minus" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
+          </ButtonGroup.Button>
+        </ButtonGroup>
+      </PdfViewer>
+
+      <Form onSubmit={handleSubmit}>
+        <FieldContainer>
+          <Field>
+            <Label htmlFor="title">제목</Label>
+            <Input id="title" name="title" onChange={(e) => onChangeTitle(e.target.value)} />
+          </Field>
+
+          <Field>
+            <Label htmlFor="scope">공개 범위</Label>
+            <Select
+              width="100%"
+              onSelectOption={(option) => {
+                if (option && typeof option.name === 'string' && typeof option.value === 'number')
+                  onChangeSelectedScope({ id: option.value, scope: option.name });
+              }}
+            >
+              <Select.TriggerButton height="2.875rem" />
+              <Select.OptionList maxHeight="12.5rem">
+                {scopeList?.map(({ id, scope }) => {
+                  return (
+                    <Select.OptionItem key={id} value={id} name={scope}>
+                      {scope}
+                    </Select.OptionItem>
+                  );
+                })}
+              </Select.OptionList>
+            </Select>
+          </Field>
+
+          <Field>
+            <Label htmlFor="scope">직군</Label>
+            <Select
+              width="100%"
+              onSelectOption={(option) => {
+                if (option && typeof option.name === 'string' && typeof option.value === 'number')
+                  onChangeSelectedOccupation({ id: option.value, occupation: option.name });
+              }}
+            >
+              <Select.TriggerButton height="2.875rem" />
+              <Select.OptionList maxHeight="12.5rem">
+                {occupationList?.map(({ id, occupation }) => {
+                  return (
+                    <Select.OptionItem key={id} value={id} name={occupation}>
+                      {occupation}
+                    </Select.OptionItem>
+                  );
+                })}
+              </Select.OptionList>
+            </Select>
+          </Field>
+
+          <Field>
+            <Label htmlFor="year">재직 기간</Label>
+            <Input
+              type="number"
+              id="year"
+              name="year"
+              placeholder="신입일 경우 0 입력"
+              min={0}
+              onChange={(e) => onChangeYear(e.target.valueAsNumber)}
+            />
+          </Field>
+        </FieldContainer>
+
+        <Button variant="default" size="m">
+          수정하기
+        </Button>
+      </Form>
+    </ResumeFormLayout>
+  );
+};
+
+export default ResumeUpdateForm;

--- a/src/components/ResumeForm/ResumeUploadForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUploadForm/index.tsx
@@ -5,10 +5,9 @@ import PdfViewer from '@components/PdfViewer';
 import useMediaQuery from '@hooks/useMediaQuery';
 import usePdf from '@hooks/usePdf';
 import { Occupation, Scope, useOccupationList, useScopeList } from '@apis/utilApi';
-import { Field, FieldContainer, FileLabel, Form, ResumeFormLayout, Label } from './style';
+import { Field, FieldContainer, FileLabel, Form, ResumeFormLayout, Label } from '../style';
 
 interface Props {
-  type: 'upload' | 'update';
   file?: File;
   title: string;
   year?: number;
@@ -34,8 +33,7 @@ interface Props {
   }) => void;
 }
 
-const ResumeForm = ({
-  type,
+const ResumeUploadForm = ({
   file,
   title,
   year,
@@ -189,11 +187,11 @@ const ResumeForm = ({
         </FieldContainer>
 
         <Button variant="default" size="m">
-          {type === 'upload' ? '올리기' : '수정하기'}
+          올리기
         </Button>
       </Form>
     </ResumeFormLayout>
   );
 };
 
-export default ResumeForm;
+export default ResumeUploadForm;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,7 @@ export const ROUTE_PATH = {
   RESUME: '/resume',
   MY_RESUME: '/my-resume',
   RESUME_UPLOAD: '/resume-upload',
+  RESUME_UPDATE: '/resume-update',
   SOCIAL_LOGIN: '/path',
 } as const;
 

--- a/src/pages/ResumeUpdate/index.tsx
+++ b/src/pages/ResumeUpdate/index.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Icon } from 'review-me-design-system';
+import ResumeUpdateForm from '@components/ResumeForm/ResumeUpdateForm';
+import { useResumeDetail, useUpdateResume } from '@apis/resumeApi';
+import { Occupation, Scope, useOccupationList, useScopeList } from '@apis/utilApi';
+import { PageMain } from '@styles/common';
+import { ResumeUploadContainer, IconButton, Description, MainDescription } from './style';
+
+interface Location {
+  state: { id: number; title: string; year: number; occupation: string; scope: string };
+}
+
+const ResumeUpdate = () => {
+  const {
+    state: { id: resumeId, title: prevTitle, year: prevYear, occupation: prevOccupation, scope: prevScope },
+  } = useLocation() as Location;
+
+  const navigate = useNavigate();
+
+  const { data: resumeDetail } = useResumeDetail(resumeId);
+  const { data: occupationList } = useOccupationList();
+  const { data: scopeList } = useScopeList();
+
+  const file = resumeDetail?.resumeUrl;
+
+  const prevOccupationState = occupationList?.find(({ occupation }) => occupation === prevOccupation);
+  const prevScopeState = scopeList?.find(({ scope }) => scope === prevScope);
+
+  const [title, setTitle] = useState<string>(prevTitle);
+  const [selectedOccupation, setSelectedOccupation] = useState<Occupation | undefined>(prevOccupationState);
+  const [selectedScope, setSelectedScope] = useState<Scope | undefined>(prevScopeState);
+  const [year, setYear] = useState<number | undefined>(prevYear);
+
+  const { mutate: updateResume } = useUpdateResume();
+
+  return (
+    <PageMain>
+      <IconButton onClick={() => navigate(-1)}>
+        <Icon iconName="leftArrow" />
+        <span>뒤로</span>
+      </IconButton>
+
+      <ResumeUploadContainer>
+        <Description>
+          <MainDescription>이력서 수정</MainDescription>
+        </Description>
+
+        <ResumeUpdateForm
+          resumeId={resumeId}
+          file={file}
+          title={title}
+          year={year}
+          selectedOccupation={selectedOccupation}
+          selectedScope={selectedScope}
+          onChangeTitle={setTitle}
+          onChangeYear={setYear}
+          onChangeSelectedOccupation={setSelectedOccupation}
+          onChangeSelectedScope={setSelectedScope}
+          onSubmit={updateResume}
+        />
+      </ResumeUploadContainer>
+    </PageMain>
+  );
+};
+
+export default ResumeUpdate;

--- a/src/pages/ResumeUpdate/style.ts
+++ b/src/pages/ResumeUpdate/style.ts
@@ -1,0 +1,40 @@
+import { theme } from 'review-me-design-system';
+import styled from 'styled-components';
+
+const IconButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  width: fit-content;
+
+  background-color: transparent;
+
+  ${theme.font.body.default}
+  color: ${theme.color.neutral.text.default};
+
+  cursor: pointer;
+`;
+
+const ResumeUploadContainer = styled.div`
+  display: flex;
+  padding: 1rem;
+  flex-direction: column;
+  gap: 1rem;
+
+  border-radius: 1rem;
+  background-color: ${theme.color.neutral.bg.default};
+`;
+
+const Description = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+`;
+
+const MainDescription = styled.span`
+  ${theme.font.title.medium}
+  color: ${theme.color.neutral.text.strong};
+`;
+
+export { IconButton, ResumeUploadContainer, Description, MainDescription };

--- a/src/pages/ResumeUpload/index.tsx
+++ b/src/pages/ResumeUpload/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Icon } from 'review-me-design-system';
-import ResumeForm from '@components/ResumeForm';
+import ResumeUploadForm from '@components/ResumeForm/ResumeUploadForm';
 import { usePostResume } from '@apis/resumeApi';
 import { Occupation, Scope } from '@apis/utilApi';
 import { PageMain } from '@styles/common';
@@ -30,8 +30,7 @@ const ResumeUpload = () => {
           <SubDescription>제출된 이력서 pdf 파일은 변경이 불가합니다.</SubDescription>
         </Description>
 
-        <ResumeForm
-          type="upload"
+        <ResumeUploadForm
           file={file}
           title={title}
           year={year}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,7 @@ import MyPage from '@pages/MyPage';
 import MyResume from '@pages/MyResume';
 import Resume from '@pages/Resume';
 import ResumeDetail from '@pages/ResumeDetail';
+import ResumeUpdate from '@pages/ResumeUpdate';
 import ResumeUpload from '@pages/ResumeUpload';
 import SocialLogin from '@pages/SocialLogin';
 import { ROUTE_PATH } from '@constants';
@@ -27,6 +28,7 @@ const router = createBrowserRouter([
       { path: `${ROUTE_PATH.RESUME}/:resumeId`, element: <ResumeDetail /> },
       { path: ROUTE_PATH.MY_RESUME, element: <MyResume /> },
       { path: ROUTE_PATH.RESUME_UPLOAD, element: <ResumeUpload /> },
+      { path: ROUTE_PATH.RESUME_UPDATE, element: <ResumeUpdate /> },
       { path: ROUTE_PATH.SOCIAL_LOGIN, element: <SocialLogin /> },
     ],
   },


### PR DESCRIPTION
## 개요

이력서 수정 페이지를 만들었다.

## 작업 사항

- 내 이력서 항목에서 `수정` 버튼 클릭 시, 이력서 수정 페이지로 이동
- 이력서 수정 페이지 구현
- 이력서 수정 Form 컴포넌트 생성 (`ResumeUpdateForm`)
- 이력서 수정하는 API 요청 로직 구현

## 이슈 번호

close #70 
