### PR TITLE
[FE] 대댓글 컴포넌트 생성 및 대댓글 데이터 GET 요청 로직 구현

### DIFF
--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -70,6 +70,63 @@ export const useFeedbackList = ({ resumeId, resumePage, enabled }: UseFeedbackLi
   });
 };
 
+// GET 피드백에 달린 댓글 조회
+export interface FeedbackReply {
+  id: number;
+  parentFeedbackId: number;
+  content: string;
+  commenterId: number;
+  commenterName: string;
+  commenterProfileUrl: string;
+  createdAt: string;
+  emojis: Emoji[];
+  myEmojiId: number | null;
+}
+
+interface GetFeedbackReplyList extends PageNationData {
+  feedbackComments: FeedbackReply[];
+}
+
+export const getFeedbackReplyList = async ({
+  resumeId,
+  feedbackId,
+  pageParam,
+}: {
+  resumeId: number;
+  feedbackId: number;
+  pageParam: number;
+}) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/feedback/${feedbackId}?page=${pageParam}`);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetFeedbackReplyList> = await response.json();
+
+  return data;
+};
+
+interface UseFeedbackReplyListProps {
+  resumeId: number;
+  feedbackId: number;
+  enabled: boolean;
+}
+
+export const useFeedbackReplyList = ({ resumeId, feedbackId, enabled }: UseFeedbackReplyListProps) => {
+  return useInfiniteQuery({
+    queryKey: ['feedbackReplyList', resumeId, feedbackId],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getFeedbackReplyList({ resumeId, feedbackId, pageParam }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+    enabled,
+  });
+};
+
 // POST 피드백 작성
 export const postFeedback = async ({
   resumeId,

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -71,6 +71,63 @@ export const useQuestionList = ({ resumeId, resumePage, enabled }: UseQuestionLi
   });
 };
 
+// GET 예상질문에 달린 댓글 조회
+interface QuestionReply {
+  id: number;
+  parentQuestionId: number;
+  content: string;
+  commenterId: number;
+  commenterName: string;
+  commenterProfileUrl: string;
+  createdAt: string;
+  emojis: Emoji[];
+  myEmojiId: number | null;
+}
+
+interface GetQuestionReplyList extends PageNationData {
+  questionComments: QuestionReply[];
+}
+
+export const getQuestionReplyList = async ({
+  resumeId,
+  questionId,
+  pageParam,
+}: {
+  resumeId: number;
+  questionId: number;
+  pageParam: number;
+}) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question/${questionId}?page=${pageParam}`);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetQuestionReplyList> = await response.json();
+
+  return data;
+};
+
+interface UseQuestionReplyListProps {
+  resumeId: number;
+  questionId: number;
+  enabled: boolean;
+}
+
+export const useQuestionReplyList = ({ resumeId, questionId, enabled }: UseQuestionReplyListProps) => {
+  return useInfiniteQuery({
+    queryKey: ['questionReplyList', resumeId, questionId],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getQuestionReplyList({ resumeId, questionId, pageParam }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+    enabled,
+  });
+};
+
 // POST 예상 질문 추가
 export const postQuestion = async ({
   resumeId,

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { Icon, Label as EmojiLabel, theme, Label } from 'review-me-design-system';
+import ReplyList, { Reply } from '@components/ReplyList';
 import useHover from '@hooks/useHover';
+import { useFeedbackReplyList } from '@apis/feedbackApi';
+import { useQuestionReplyList } from '@apis/questionApi';
 import { useEmojiList } from '@apis/utilApi';
 import { formatDate } from '@utils';
 import {
@@ -30,7 +34,8 @@ type Emoji = {
 };
 
 interface Props {
-  // id: number;
+  type: 'feedback' | 'question' | 'comment';
+  id: number;
   content: string | null;
   commenterId: number;
   commenterName: string;
@@ -46,7 +51,8 @@ interface Props {
 }
 
 const Comment = ({
-  // id,
+  type,
+  id,
   content,
   commenterId,
   commenterName,
@@ -60,125 +66,169 @@ const Comment = ({
   myEmojiId,
   writerId,
 }: Props) => {
+  const { resumeId } = useParams();
   const { isHover, changeHoverState } = useHover();
+  const [isOpenReplyList, setIsOpenReplyList] = useState<boolean>(false);
 
   const ICON_SIZE = 24;
 
-  const hasReplyIcon = typeof countOfReplies === 'number';
+  const hasReplyIcon = typeof countOfReplies === 'number' && type !== 'comment';
   const hasCheckMarkIcon = typeof checked === 'boolean';
   const hasBookMarkIcon = typeof bookmarked === 'boolean';
 
   const { data: emojiList } = useEmojiList();
+  const { data: feedbackReplyList, fetchNextPage: fetchNextFeedbackList } = useFeedbackReplyList({
+    resumeId: Number(resumeId),
+    feedbackId: id,
+    enabled: type === 'feedback' && isOpenReplyList,
+  });
+  const { data: questionReplyList, fetchNextPage: fetchNextQuestionList } = useQuestionReplyList({
+    resumeId: Number(resumeId),
+    questionId: id,
+    enabled: type === 'question' && isOpenReplyList,
+  });
+
+  const handleReplyButtonClick = () => {
+    if (!hasReplyIcon) return;
+
+    if (!isOpenReplyList) {
+      if (type === 'feedback') fetchNextFeedbackList();
+      if (type === 'question') fetchNextQuestionList();
+    }
+
+    setIsOpenReplyList((prev) => !prev);
+  };
+
+  let replies: Reply[] = [];
+
+  if (type === 'feedback' && feedbackReplyList)
+    replies = feedbackReplyList.pages
+      .map((page) => page.feedbackComments)
+      .flat()
+      .map((reply) => ({ ...reply, parentId: reply.parentFeedbackId }));
+  if (type === 'question' && questionReplyList)
+    replies = questionReplyList.pages
+      .map((page) => page.questionComments)
+      .flat()
+      .map((reply) => ({ ...reply, parentId: reply.parentQuestionId }));
 
   return (
-    <CommentLayout>
-      <Top>
-        <Info>
-          <UserImg src={commenterProfileUrl} />
-          <CommentInfo>
-            <UserName>{commenterName}</UserName>
-            <Time>{formatDate(createdAt)}</Time>
-          </CommentInfo>
-        </Info>
+    <>
+      <CommentLayout>
+        <Top>
+          <Info>
+            <UserImg src={commenterProfileUrl} />
+            <CommentInfo>
+              <UserName>{commenterName}</UserName>
+              <Time>{formatDate(createdAt)}</Time>
+            </CommentInfo>
+          </Info>
 
-        <div>
-          {hasBookMarkIcon && (
+          <div>
+            {hasBookMarkIcon && (
+              <IconButton>
+                {bookmarked ? (
+                  <Icon
+                    iconName="filledBookMark"
+                    width={ICON_SIZE}
+                    height={ICON_SIZE}
+                    color={theme.color.accent.bg.default}
+                  />
+                ) : (
+                  <Icon
+                    iconName="bookMark"
+                    width={ICON_SIZE}
+                    height={ICON_SIZE}
+                    color={theme.color.accent.bg.strong}
+                  />
+                )}
+              </IconButton>
+            )}
+            {hasCheckMarkIcon && (
+              <IconButton>
+                {checked ? (
+                  <Icon
+                    iconName="filledCheckMark"
+                    width={ICON_SIZE}
+                    height={ICON_SIZE}
+                    color={theme.color.accent.bg.default}
+                  />
+                ) : (
+                  <Icon
+                    iconName="checkMark"
+                    width={ICON_SIZE}
+                    height={ICON_SIZE}
+                    color={theme.color.accent.bg.strong}
+                  />
+                )}
+              </IconButton>
+            )}
             <IconButton>
-              {bookmarked ? (
-                <Icon
-                  iconName="filledBookMark"
-                  width={ICON_SIZE}
-                  height={ICON_SIZE}
-                  color={theme.color.accent.bg.default}
-                />
-              ) : (
-                <Icon
-                  iconName="bookMark"
-                  width={ICON_SIZE}
-                  height={ICON_SIZE}
-                  color={theme.color.accent.bg.strong}
-                />
-              )}
+              <Icon
+                iconName="more"
+                width={ICON_SIZE}
+                height={ICON_SIZE}
+                color={theme.color.accent.bg.strong}
+              />
             </IconButton>
-          )}
-          {hasCheckMarkIcon && (
-            <IconButton>
-              {checked ? (
-                <Icon
-                  iconName="filledCheckMark"
-                  width={ICON_SIZE}
-                  height={ICON_SIZE}
-                  color={theme.color.accent.bg.default}
-                />
-              ) : (
-                <Icon
-                  iconName="checkMark"
-                  width={ICON_SIZE}
-                  height={ICON_SIZE}
-                  color={theme.color.accent.bg.strong}
-                />
-              )}
-            </IconButton>
-          )}
-          <IconButton>
-            <Icon iconName="more" width={ICON_SIZE} height={ICON_SIZE} color={theme.color.accent.bg.strong} />
-          </IconButton>
-        </div>
-      </Top>
+          </div>
+        </Top>
 
-      <CommentContent>
-        {labelContent && <SelectedLabel>{labelContent}</SelectedLabel>}
-        <Content>{content}</Content>
-      </CommentContent>
+        <CommentContent>
+          {labelContent && <SelectedLabel>{labelContent}</SelectedLabel>}
+          <Content>{content}</Content>
+        </CommentContent>
 
-      <Bottom>
-        {hasReplyIcon && (
-          <OpenReplyButton>
-            <Icon iconName="communication" width={ICON_SIZE} height={ICON_SIZE} />
-            <span>{countOfReplies}</span>
-          </OpenReplyButton>
-        )}
-        <EmojiButtonContainer>
-          <EmojiButton
-            onMouseEnter={() => changeHoverState(true)}
-            onMouseLeave={() => changeHoverState(false)}
-          >
-            <Icon iconName="emoji" />
-          </EmojiButton>
-          <EmojiModal
-            className={isHover ? 'active' : ''}
-            onMouseEnter={() => changeHoverState(true)}
-            onMouseLeave={() => changeHoverState(false)}
-          >
-            {emojiList?.map(({ id, emoji }) => {
+        <Bottom>
+          {hasReplyIcon && (
+            <OpenReplyButton onClick={handleReplyButtonClick}>
+              <Icon iconName="communication" width={ICON_SIZE} height={ICON_SIZE} />
+              <span>{countOfReplies}</span>
+            </OpenReplyButton>
+          )}
+          <EmojiButtonContainer>
+            <EmojiButton
+              onMouseEnter={() => changeHoverState(true)}
+              onMouseLeave={() => changeHoverState(false)}
+            >
+              <Icon iconName="emoji" />
+            </EmojiButton>
+            <EmojiModal
+              className={isHover ? 'active' : ''}
+              onMouseEnter={() => changeHoverState(true)}
+              onMouseLeave={() => changeHoverState(false)}
+            >
+              {emojiList?.map(({ id, emoji }) => {
+                return (
+                  <Label key={id} isActive={id === myEmojiId} py="0.5rem" px="0.75rem">
+                    {emoji}
+                  </Label>
+                );
+              })}
+            </EmojiModal>
+          </EmojiButtonContainer>
+
+          <EmojiLabelList>
+            {emojis.map(({ id, count }) => {
+              const hasEmoji = count > 0;
+
+              if (!hasEmoji) return;
+
+              const emoji = emojiList?.find(({ id: emojiId }) => emojiId === id)?.emoji;
+
               return (
-                <Label key={id} isActive={id === myEmojiId} py="0.5rem" px="0.75rem">
-                  {emoji}
-                </Label>
+                <EmojiLabelItem key={id}>
+                  <EmojiLabel isActive={id === myEmojiId} py="0" px="0.75rem">
+                    {`${emoji} ${count}`}
+                  </EmojiLabel>
+                </EmojiLabelItem>
               );
             })}
-          </EmojiModal>
-        </EmojiButtonContainer>
-
-        <EmojiLabelList>
-          {emojis.map(({ id, count }) => {
-            const hasEmoji = count > 0;
-
-            if (!hasEmoji) return;
-
-            const emoji = emojiList?.find(({ id: emojiId }) => emojiId === id)?.emoji;
-
-            return (
-              <EmojiLabelItem key={id}>
-                <EmojiLabel isActive={id === myEmojiId} py="0" px="0.75rem">
-                  {`${emoji} ${count}`}
-                </EmojiLabel>
-              </EmojiLabelItem>
-            );
-          })}
-        </EmojiLabelList>
-      </Bottom>
-    </CommentLayout>
+          </EmojiLabelList>
+        </Bottom>
+      </CommentLayout>
+      {isOpenReplyList && <ReplyList type={type} replies={replies} />}
+    </>
   );
 };
 

--- a/src/components/ReplyList/index.tsx
+++ b/src/components/ReplyList/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Button, Textarea } from 'review-me-design-system';
+import Comment from '@components/Comment';
+import { ReplyForm, ReplyListLayout } from './style';
+
+type Emoji = {
+  id: number;
+  count: number;
+};
+
+export interface Reply {
+  id: number;
+  parentId: number;
+  content: string | null;
+  commenterId: number;
+  commenterName: string;
+  commenterProfileUrl: string;
+  createdAt: string;
+  emojis: Emoji[];
+  myEmojiId: number | null;
+}
+
+interface Props {
+  type: 'feedback' | 'question' | 'comment';
+  replies: Reply[];
+}
+
+const ReplyList = ({ type, replies }: Props) => {
+  return (
+    <ReplyListLayout>
+      {replies.map((reply) => (
+        <li key={reply.id}>
+          <Comment type={type} {...reply} />
+        </li>
+      ))}
+      <ReplyForm>
+        <Textarea placeholder="댓글" />
+        <Button variant="default" size="s">
+          작성
+        </Button>
+      </ReplyForm>
+    </ReplyListLayout>
+  );
+};
+
+export default ReplyList;

--- a/src/components/ReplyList/style.ts
+++ b/src/components/ReplyList/style.ts
@@ -1,0 +1,24 @@
+import { theme } from 'review-me-design-system';
+import styled from 'styled-components';
+
+const ReplyForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+  gap: 0.5rem;
+
+  & > button {
+    flex-shrink: 0;
+  }
+`;
+
+const ReplyListLayout = styled.ul`
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 1rem;
+
+  background-color: ${theme.palette.green100};
+`;
+
+export { ReplyForm, ReplyListLayout };

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -209,34 +209,7 @@ const ResumeDetail = () => {
               feedbackList?.map((feedback) => {
                 return (
                   <li key={feedback.id}>
-                    <Comment {...feedback} />
-                    {/* <ReplyList>
-                      <Comment
-                        content="프로젝트에서 react-query를 사용하셨는데 사용한 이유가 궁금합니다."
-                        commenterId={1}
-                        writerId={1}
-                        commenterName="aken-you"
-                        commenterProfileUrl="https://avatars.githubusercontent.com/u/96980857?v=4"
-                        createdAt="2024-01-24 16:19:37"
-                        emojis={[
-                          {
-                            id: 1,
-                            count: 10,
-                          },
-                          {
-                            id: 2,
-                            count: 3,
-                          },
-                        ]}
-                        myEmojiId={1}
-                      />
-                      <ReplyForm>
-                        <Textarea placeholder="댓글" />
-                        <Button variant="default" size="s">
-                          작성
-                        </Button>
-                      </ReplyForm>
-                    </ReplyList> */}
+                    <Comment type="feedback" {...feedback} />
                   </li>
                 );
               })}
@@ -244,7 +217,7 @@ const ResumeDetail = () => {
               questionList?.map((question) => {
                 return (
                   <li key={question.id}>
-                    <Comment {...question} />
+                    <Comment type="question" {...question} />
                   </li>
                 );
               })}
@@ -252,7 +225,7 @@ const ResumeDetail = () => {
               commentList?.map((comment) => {
                 return (
                   <li key={comment.id}>
-                    <Comment {...comment} />
+                    <Comment type="comment" {...comment} />
                   </li>
                 );
               })}

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -28,8 +28,6 @@ import {
   WriterImg,
   WriterInfo,
   WriterInfoContainer,
-  ReplyList,
-  ReplyForm,
   ResumeViewer,
   KeywordLabel,
 } from './style';

--- a/src/pages/ResumeDetail/style.ts
+++ b/src/pages/ResumeDetail/style.ts
@@ -139,18 +139,6 @@ const FormContent = styled.div`
   }
 `;
 
-const ReplyForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: flex-end;
-  gap: 0.5rem;
-
-  & > button {
-    flex-shrink: 0;
-  }
-`;
-
 const KeywordLabel = styled.span`
   display: flex;
   justify-content: center;
@@ -174,15 +162,6 @@ const CommentList = styled.ul`
   height: 100%;
 `;
 
-const ReplyList = styled.ul`
-  display: flex;
-  flex-direction: column;
-  padding: 0 1rem;
-  padding-bottom: 0.75rem;
-
-  background-color: ${theme.palette.green100};
-`;
-
 export {
   Main,
   ResumeViewer,
@@ -202,6 +181,4 @@ export {
   KeywordLabel,
   LabelList,
   CommentList,
-  ReplyList,
-  ReplyForm,
 };


### PR DESCRIPTION
## 개요

Comment 컴포넌트에서 대댓글 아이콘 버튼을 클릭할 경우, 해당 댓글의 대댓글 데이터를 요청한다. 이 데이터는 대댓글 컴포넌트에게 전달되어, 사용자에게 해당 댓글에 대한 대댓글을 표시된다.

## 작업 사항

- 대댓글 컴포넌트(`ReplyList`) 생성
- Comment 컴포넌트의 prop에 type 추가
  - type은 comment, feedback, question 중 하나
  - 추가한 이유는 해당 컴포넌트가 피드백 댓글인지, 예상질문 댓글인지, 일반적인 댓글인지 구분하기 위해 추가
- 피드백 대댓글 목록 조회하는 hook 생성
- 예상질문 대댓글 목록 조회하는 hook 생성

## 이슈 번호

close #74 