### PR TITLE
[FE] refresh token을 이용해 jwt 재발급 받는 기능 구현 및 로그인 로직 수정

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -1,17 +1,19 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse } from './response.types';
 
+// POST jwt 발급
 interface GetJwt {
   jwt: string;
 }
 
-const getJwt = async (code: string | null) => {
-  const response = await fetch(`${REQUEST_URL.OAUTH}?code=${code}`, {
-    method: 'GET',
+const getJwt = async (code: string) => {
+  const response = await fetch(`${REQUEST_URL.OAUTH}`, {
+    method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
+    body: JSON.stringify({ code }),
     credentials: 'include',
   });
 
@@ -24,10 +26,8 @@ const getJwt = async (code: string | null) => {
   return data;
 };
 
-export const useJwt = (code: string | null) => {
-  return useQuery({
-    queryKey: ['jwt'],
-    queryFn: () => getJwt(code),
-    enabled: !!code,
+export const useJwt = () => {
+  return useMutation({
+    mutationFn: getJwt,
   });
 };

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -62,5 +62,6 @@ export const useRenewJwt = () => {
     queryFn: getRenewedJwt,
     staleTime: JWT_EXPIRED_TIME,
     refetchInterval: JWT_REFRESH_INTERVAL,
+    retry: false,
   });
 };

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -1,20 +1,17 @@
-import { useNavigate } from 'react-router-dom';
-import { useMutation } from '@tanstack/react-query';
-import { useUserContext } from '@contexts/userContext';
+import { useQuery } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse } from './response.types';
 
-interface PostAuthorizationCode {
+interface GetJwt {
   jwt: string;
 }
 
-const postAuthorizationCode = async (code: string) => {
-  const response = await fetch(REQUEST_URL.OAUTH, {
-    method: 'POST',
+const getJwt = async (code: string | null) => {
+  const response = await fetch(`${REQUEST_URL.OAUTH}?code=${code}`, {
+    method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ code }),
     credentials: 'include',
   });
 
@@ -22,20 +19,15 @@ const postAuthorizationCode = async (code: string) => {
     throw response;
   }
 
-  const { data }: ApiResponse<PostAuthorizationCode> = await response.json();
+  const { data }: ApiResponse<GetJwt> = await response.json();
 
   return data;
 };
 
-export const usePostAuthorizationCode = () => {
-  const navigate = useNavigate();
-  const { login } = useUserContext();
-
-  return useMutation({
-    mutationFn: postAuthorizationCode,
-    onSuccess: ({ jwt }) => {
-      login(jwt);
-      navigate('/');
-    },
+export const useJwt = (code: string | null) => {
+  return useQuery({
+    queryKey: ['jwt'],
+    queryFn: () => getJwt(code),
+    enabled: !!code,
   });
 };

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -31,3 +31,36 @@ export const useJwt = () => {
     mutationFn: getJwt,
   });
 };
+
+// GET refresh token을 통해 jwt 재발급
+interface GetRenewedJwt {
+  jwt: string;
+}
+
+const getRenewedJwt = async () => {
+  const response = await fetch(`${REQUEST_URL.RENEW_JWT}`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetRenewedJwt> = await response.json();
+
+  return data;
+};
+
+export const useRenewJwt = () => {
+  // jwt 갱신 주기: 10분
+  const JWT_REFRESH_INTERVAL = 10 * 60 * 1000;
+  const JWT_EXPIRED_TIME = 60 * 60 * 1000;
+
+  return useQuery({
+    queryKey: ['jwt'],
+    queryFn: getRenewedJwt,
+    staleTime: JWT_EXPIRED_TIME,
+    refetchInterval: JWT_REFRESH_INTERVAL,
+  });
+};

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { useUserContext } from '@contexts/userContext';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse } from './response.types';
 
@@ -56,6 +57,7 @@ export const useRenewJwt = () => {
   // jwt 갱신 주기: 10분
   const JWT_REFRESH_INTERVAL = 10 * 60 * 1000;
   const JWT_EXPIRED_TIME = 60 * 60 * 1000;
+  const { isLoggedIn } = useUserContext();
 
   return useQuery({
     queryKey: ['jwt'],
@@ -63,5 +65,6 @@ export const useRenewJwt = () => {
     staleTime: JWT_EXPIRED_TIME,
     refetchInterval: JWT_REFRESH_INTERVAL,
     retry: false,
+    enabled: !!isLoggedIn,
   });
 };

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Button, Icon, theme } from 'review-me-design-system';
 import useMediaQuery from '@hooks/useMediaQuery';
+import { useUserContext } from '@contexts/userContext';
 import { ROUTE_PATH } from '@constants';
 import { manageBodyScroll } from '@utils';
 import {
@@ -25,6 +26,7 @@ import {
 const Header = () => {
   const navigate = useNavigate();
   const { matches: isSMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 600px)' });
+  const { isLoggedIn, logout } = useUserContext();
   const [isOpenMobileMenu, setIsOpenMobileMenu] = useState<boolean>(false);
 
   const handleOpenMobileMenu = () => {
@@ -42,7 +44,8 @@ const Header = () => {
   };
 
   const CLIENT_ID = process.env.DEV_CLIENT_ID;
-  const REDIRECT_URI = process.env.DEV_REDIRECT_URI;
+  const REDIRECT_URI =
+    process.env.NODE_ENV === 'development' ? process.env.DEV_REDIRECT_URI : process.env.PROD_REDIRECT_URI;
   const GITHUB_OAUTH_URI = `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}`;
 
   const handleLogin = () => {
@@ -76,18 +79,19 @@ const Header = () => {
                 </MobileMenuItem>
               </MobileMenuList>
 
-              <JoinUsMessage>
-                <span>review me에 가입하여</span>
-                <span>다른 사람들과 이력서를 공유해보세요.</span>
-              </JoinUsMessage>
+              {!isLoggedIn && (
+                <JoinUsMessage>
+                  <span>review me에 가입하여</span>
+                  <span>다른 사람들과 이력서를 공유해보세요.</span>
+                </JoinUsMessage>
+              )}
 
               <MobileMenuButtonContainer>
-                <Button variant="default" size="s">
-                  회원 가입
-                </Button>
-                <Button variant="outline" size="s" onClick={handleLogin}>
-                  github으로 로그인
-                </Button>
+                {!isLoggedIn && (
+                  <Button variant="outline" size="s" onClick={handleLogin}>
+                    github으로 시작
+                  </Button>
+                )}
               </MobileMenuButtonContainer>
             </MobileMenu>
             {isOpenMobileMenu && <BackDrop onClick={handleCloseMobileMenu} />}
@@ -118,8 +122,8 @@ const Header = () => {
             <Icon iconName="person" color={theme.color.accent.text.strong} width={32} height={32} />
           </IconButton>
           {!isSMDevice && (
-            <Button variant="default" size="s" onClick={handleLogin}>
-              로그인
+            <Button variant="default" size="s" onClick={isLoggedIn ? logout : handleLogin}>
+              {isLoggedIn ? '로그아웃' : '로그인'}
             </Button>
           )}
         </RightContainer>

--- a/src/components/TokenRefresh/index.tsx
+++ b/src/components/TokenRefresh/index.tsx
@@ -9,19 +9,28 @@ interface Props {
 const TokenRefresh = ({ children }: Props) => {
   const { getRenewedJwtQuery } = useAuth();
   const { isSuccess, refetch, isFetched, data, isError } = getRenewedJwtQuery;
-  const { login, logout } = useUserContext();
+  const { login, logout, isLoggedIn } = useUserContext();
 
   useEffect(() => {
+    const shouldRefreshJwt = isLoggedIn;
+
+    if (!shouldRefreshJwt) return;
+
     if (!isFetched) {
       refetch();
+      return;
     }
-    if (isSuccess) {
+
+    const isJwtRenewalSuccessful = isSuccess && data;
+    const isJwtRenewalFailed = isError;
+
+    if (isJwtRenewalSuccessful) {
       login(data.jwt);
     }
-    if (isError) {
+    if (isJwtRenewalFailed) {
       logout();
     }
-  }, [isSuccess, isFetched, data]);
+  }, [isSuccess, isFetched, data, isLoggedIn]);
 
   return <>{children}</>;
 };

--- a/src/components/TokenRefresh/index.tsx
+++ b/src/components/TokenRefresh/index.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect } from 'react';
+import useAuth from '@hooks/useAuth';
 import { useUserContext } from '@contexts/userContext';
-import { useRenewJwt } from '@apis/login';
 
 interface Props {
   children: React.ReactNode;
 }
 
 const TokenRefresh = ({ children }: Props) => {
-  const { isSuccess, refetch, isFetched, data } = useRenewJwt();
+  const { getRenewedJwtQuery } = useAuth();
+  const { isSuccess, refetch, isFetched, data } = getRenewedJwtQuery;
   const { login } = useUserContext();
 
   useEffect(() => {

--- a/src/components/TokenRefresh/index.tsx
+++ b/src/components/TokenRefresh/index.tsx
@@ -8,8 +8,8 @@ interface Props {
 
 const TokenRefresh = ({ children }: Props) => {
   const { getRenewedJwtQuery } = useAuth();
-  const { isSuccess, refetch, isFetched, data } = getRenewedJwtQuery;
-  const { login } = useUserContext();
+  const { isSuccess, refetch, isFetched, data, isError } = getRenewedJwtQuery;
+  const { login, logout } = useUserContext();
 
   useEffect(() => {
     if (!isFetched) {
@@ -17,6 +17,9 @@ const TokenRefresh = ({ children }: Props) => {
     }
     if (isSuccess) {
       login(data.jwt);
+    }
+    if (isError) {
+      logout();
     }
   }, [isSuccess, isFetched, data]);
 

--- a/src/components/TokenRefresh/index.tsx
+++ b/src/components/TokenRefresh/index.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const TokenRefresh = ({ children }: Props) => {
   const { getRenewedJwtQuery } = useAuth();
-  const { isSuccess, refetch, isFetched, data, isError } = getRenewedJwtQuery;
+  const { isSuccess, refetch, isFetched, data, isError, status } = getRenewedJwtQuery;
   const { login, logout, isLoggedIn } = useUserContext();
 
   useEffect(() => {
@@ -31,6 +31,12 @@ const TokenRefresh = ({ children }: Props) => {
       logout();
     }
   }, [isSuccess, isFetched, data, isLoggedIn]);
+
+  const isRenewedJwtNotReceived = status === 'pending' && isLoggedIn;
+
+  if (isRenewedJwtNotReceived) {
+    return <></>;
+  }
 
   return <>{children}</>;
 };

--- a/src/components/TokenRefresh/index.tsx
+++ b/src/components/TokenRefresh/index.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { useUserContext } from '@contexts/userContext';
+import { useRenewJwt } from '@apis/login';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const TokenRefresh = ({ children }: Props) => {
+  const { isSuccess, refetch, isFetched, data } = useRenewJwt();
+  const { login } = useUserContext();
+
+  useEffect(() => {
+    if (!isFetched) {
+      refetch();
+    }
+    if (isSuccess) {
+      login(data.jwt);
+    }
+  }, [isSuccess, isFetched, data]);
+
+  return <>{children}</>;
+};
+
+export default TokenRefresh;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -27,3 +27,5 @@ export const PDF_VIEWER_SCALE = {
   MIN_SCALE: 0.6,
   SCALE_STEP: 0.2,
 } as const;
+
+export const IS_LOGGED_IN_KEY = 'isLoggedIn';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -18,6 +18,7 @@ export const REQUEST_URL = {
   EMOJI: `${BASE_URL}/emoji`,
   SCOPE: `${BASE_URL}/scope`,
   OAUTH: `${BASE_URL}/login/oauth`,
+  RENEW_JWT: `${BASE_URL}/user/refresh`,
 } as const;
 
 export const PDF_VIEWER_SCALE = {

--- a/src/contexts/userContext.tsx
+++ b/src/contexts/userContext.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, createContext, useContext, useState } from 'react';
+import { IS_LOGGED_IN_KEY } from '@constants';
 import { parseJwt } from '@utils';
 
 interface User {
@@ -43,16 +44,18 @@ const UserProvider = ({ children }: UserProviderProps) => {
 
   const login = (jwt: string) => {
     setJwt(jwt);
+    localStorage.setItem(IS_LOGGED_IN_KEY, 'true');
   };
 
   const logout = () => {
     setJwt(undefined);
+    localStorage.removeItem(IS_LOGGED_IN_KEY);
   };
 
   const parsedJwt: JwtPayload = jwt ? parseJwt(jwt) : null;
 
   const user = parsedJwt ? parsedJwt.userProfile : null;
-  const isLoggedIn = !!user;
+  const isLoggedIn = !!localStorage.getItem(IS_LOGGED_IN_KEY);
 
   return (
     <UserContext.Provider value={{ jwt, user, login, logout, isLoggedIn }}>{children}</UserContext.Provider>

--- a/src/contexts/userContext.tsx
+++ b/src/contexts/userContext.tsx
@@ -15,6 +15,7 @@ interface JwtPayload {
 interface UserContext {
   jwt?: string;
   user: User | null;
+  isLoggedIn: boolean;
   login: (jwt: string) => void;
   logout: () => void;
 }
@@ -51,8 +52,11 @@ const UserProvider = ({ children }: UserProviderProps) => {
   const parsedJwt: JwtPayload = jwt ? parseJwt(jwt) : null;
 
   const user = parsedJwt ? parsedJwt.userProfile : null;
+  const isLoggedIn = !!user;
 
-  return <UserContext.Provider value={{ jwt, user, login, logout }}>{children}</UserContext.Provider>;
+  return (
+    <UserContext.Provider value={{ jwt, user, login, logout, isLoggedIn }}>{children}</UserContext.Provider>
+  );
 };
 
 export { UserProvider, useUserContext };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useJwt, useRenewJwt } from '@apis/login';
+
+const useAuth = () => {
+  const createJwtQuery = useJwt();
+  const getRenewedJwtQuery = useRenewJwt();
+
+  return { createJwtQuery, getRenewedJwtQuery };
+};
+
+export default useAuth;

--- a/src/pages/SocialLogin/index.tsx
+++ b/src/pages/SocialLogin/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useUserContext } from '@contexts/userContext';
 import { useJwt } from '@apis/login';
 import { ROUTE_PATH } from '@constants';
 
@@ -8,23 +7,20 @@ const SocialLogin = () => {
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code');
 
-  const { refetch, data, isError, isSuccess, isFetched } = useJwt(code);
-
+  const { mutate } = useJwt();
   const navigate = useNavigate();
-  const { login } = useUserContext();
 
   useEffect(() => {
-    if (!isFetched) refetch();
-
-    if (isSuccess) {
-      login(data.jwt);
-      navigate(ROUTE_PATH.ROOT);
-    }
-    if (isError) {
-      alert('로그인에 실패했습니다.');
-      navigate(ROUTE_PATH.ROOT);
-    }
-  }, [code, isSuccess, isError, isFetched]);
+    if (code)
+      mutate(code, {
+        onError: () => {
+          alert('로그인에 실패했습니다.');
+        },
+        onSettled: () => {
+          navigate(ROUTE_PATH.ROOT);
+        },
+      });
+  }, [code]);
 
   return <></>;
 };

--- a/src/pages/SocialLogin/index.tsx
+++ b/src/pages/SocialLogin/index.tsx
@@ -9,12 +9,15 @@ const SocialLogin = () => {
   const code = searchParams.get('code');
 
   const { createJwtQuery } = useAuth();
-  const { logout } = useUserContext();
+  const { logout, login } = useUserContext();
   const navigate = useNavigate();
 
   useEffect(() => {
     if (code)
       createJwtQuery.mutate(code, {
+        onSuccess: (data) => {
+          login(data.jwt);
+        },
         onError: () => {
           alert('로그인에 실패했습니다.');
           logout();

--- a/src/pages/SocialLogin/index.tsx
+++ b/src/pages/SocialLogin/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import useAuth from '@hooks/useAuth';
+import { useUserContext } from '@contexts/userContext';
 import { ROUTE_PATH } from '@constants';
 
 const SocialLogin = () => {
@@ -8,6 +9,7 @@ const SocialLogin = () => {
   const code = searchParams.get('code');
 
   const { createJwtQuery } = useAuth();
+  const { logout } = useUserContext();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -15,6 +17,7 @@ const SocialLogin = () => {
       createJwtQuery.mutate(code, {
         onError: () => {
           alert('로그인에 실패했습니다.');
+          logout();
         },
         onSettled: () => {
           navigate(ROUTE_PATH.ROOT);

--- a/src/pages/SocialLogin/index.tsx
+++ b/src/pages/SocialLogin/index.tsx
@@ -1,15 +1,30 @@
 import React, { useEffect } from 'react';
-import { usePostAuthorizationCode } from '@apis/login';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useUserContext } from '@contexts/userContext';
+import { useJwt } from '@apis/login';
+import { ROUTE_PATH } from '@constants';
 
 const SocialLogin = () => {
-  const code = new URLSearchParams(window.location.search).get('code');
-  const { mutate } = usePostAuthorizationCode();
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get('code');
+
+  const { refetch, data, status } = useJwt(code);
+
+  const navigate = useNavigate();
+  const { login } = useUserContext();
 
   useEffect(() => {
-    if (code) {
-      mutate(code);
+    refetch();
+
+    if (status === 'success') {
+      login(data.jwt);
+      navigate(ROUTE_PATH.ROOT);
     }
-  }, []);
+    if (status === 'error') {
+      alert('로그인에 실패했습니다.');
+      navigate(ROUTE_PATH.ROOT);
+    }
+  }, [code, status, data]);
 
   return <></>;
 };

--- a/src/pages/SocialLogin/index.tsx
+++ b/src/pages/SocialLogin/index.tsx
@@ -1,18 +1,18 @@
 import React, { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useJwt } from '@apis/login';
+import useAuth from '@hooks/useAuth';
 import { ROUTE_PATH } from '@constants';
 
 const SocialLogin = () => {
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code');
 
-  const { mutate } = useJwt();
+  const { createJwtQuery } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
     if (code)
-      mutate(code, {
+      createJwtQuery.mutate(code, {
         onError: () => {
           alert('로그인에 실패했습니다.');
         },

--- a/src/pages/SocialLogin/index.tsx
+++ b/src/pages/SocialLogin/index.tsx
@@ -8,23 +8,23 @@ const SocialLogin = () => {
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code');
 
-  const { refetch, data, status } = useJwt(code);
+  const { refetch, data, isError, isSuccess, isFetched } = useJwt(code);
 
   const navigate = useNavigate();
   const { login } = useUserContext();
 
   useEffect(() => {
-    refetch();
+    if (!isFetched) refetch();
 
-    if (status === 'success') {
+    if (isSuccess) {
       login(data.jwt);
       navigate(ROUTE_PATH.ROOT);
     }
-    if (status === 'error') {
+    if (isError) {
       alert('로그인에 실패했습니다.');
       navigate(ROUTE_PATH.ROOT);
     }
-  }, [code, status, data]);
+  }, [code, isSuccess, isError, isFetched]);
 
   return <></>;
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createBrowserRouter } from 'react-router-dom';
+import { Outlet, createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
 import TokenRefresh from '@components/TokenRefresh';
@@ -19,57 +19,35 @@ const router = createBrowserRouter([
     path: ROUTE_PATH.ROOT,
     element: (
       <UserProvider>
-        <Layout />
+        <TokenRefresh>
+          <Layout />
+        </TokenRefresh>
       </UserProvider>
     ),
     children: [
       {
         index: true,
-        element: (
-          <TokenRefresh>
-            <MainPage />
-          </TokenRefresh>
-        ),
+        element: <MainPage />,
       },
       {
         path: ROUTE_PATH.MY_PAGE,
-        element: (
-          <TokenRefresh>
-            <MyPage />
-          </TokenRefresh>
-        ),
+        element: <MyPage />,
       },
       {
         path: ROUTE_PATH.RESUME,
-        element: (
-          <TokenRefresh>
-            <Resume />
-          </TokenRefresh>
-        ),
+        element: <Resume />,
       },
       {
         path: `${ROUTE_PATH.RESUME}/:resumeId`,
-        element: (
-          <TokenRefresh>
-            <ResumeDetail />
-          </TokenRefresh>
-        ),
+        element: <ResumeDetail />,
       },
       {
         path: ROUTE_PATH.MY_RESUME,
-        element: (
-          <TokenRefresh>
-            <MyResume />
-          </TokenRefresh>
-        ),
+        element: <MyResume />,
       },
       {
         path: ROUTE_PATH.RESUME_UPLOAD,
-        element: (
-          <TokenRefresh>
-            <ResumeUpload />
-          </TokenRefresh>
-        ),
+        element: <ResumeUpload />,
       },
       {
         path: ROUTE_PATH.RESUME_UPDATE,
@@ -79,8 +57,16 @@ const router = createBrowserRouter([
           </TokenRefresh>
         ),
       },
-      { path: ROUTE_PATH.SOCIAL_LOGIN, element: <SocialLogin /> },
     ],
+  },
+  {
+    path: ROUTE_PATH.ROOT,
+    element: (
+      <UserProvider>
+        <Outlet />
+      </UserProvider>
+    ),
+    children: [{ path: ROUTE_PATH.SOCIAL_LOGIN, element: <SocialLogin /> }],
   },
 ]);
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@components/Layout';
+import TokenRefresh from '@components/TokenRefresh';
 import { UserProvider } from '@contexts/userContext';
 import MainPage from '@pages/MainPage';
 import MyPage from '@pages/MyPage';
@@ -22,13 +23,62 @@ const router = createBrowserRouter([
       </UserProvider>
     ),
     children: [
-      { index: true, element: <MainPage /> },
-      { path: ROUTE_PATH.MY_PAGE, element: <MyPage /> },
-      { path: ROUTE_PATH.RESUME, element: <Resume /> },
-      { path: `${ROUTE_PATH.RESUME}/:resumeId`, element: <ResumeDetail /> },
-      { path: ROUTE_PATH.MY_RESUME, element: <MyResume /> },
-      { path: ROUTE_PATH.RESUME_UPLOAD, element: <ResumeUpload /> },
-      { path: ROUTE_PATH.RESUME_UPDATE, element: <ResumeUpdate /> },
+      {
+        index: true,
+        element: (
+          <TokenRefresh>
+            <MainPage />
+          </TokenRefresh>
+        ),
+      },
+      {
+        path: ROUTE_PATH.MY_PAGE,
+        element: (
+          <TokenRefresh>
+            <MyPage />
+          </TokenRefresh>
+        ),
+      },
+      {
+        path: ROUTE_PATH.RESUME,
+        element: (
+          <TokenRefresh>
+            <Resume />
+          </TokenRefresh>
+        ),
+      },
+      {
+        path: `${ROUTE_PATH.RESUME}/:resumeId`,
+        element: (
+          <TokenRefresh>
+            <ResumeDetail />
+          </TokenRefresh>
+        ),
+      },
+      {
+        path: ROUTE_PATH.MY_RESUME,
+        element: (
+          <TokenRefresh>
+            <MyResume />
+          </TokenRefresh>
+        ),
+      },
+      {
+        path: ROUTE_PATH.RESUME_UPLOAD,
+        element: (
+          <TokenRefresh>
+            <ResumeUpload />
+          </TokenRefresh>
+        ),
+      },
+      {
+        path: ROUTE_PATH.RESUME_UPDATE,
+        element: (
+          <TokenRefresh>
+            <ResumeUpdate />
+          </TokenRefresh>
+        ),
+      },
       { path: ROUTE_PATH.SOCIAL_LOGIN, element: <SocialLogin /> },
     ],
   },


### PR DESCRIPTION
## 개요

jwt를 지역 변수(상태)로 관리하고 있다.
이 방식을 사용하면 회원이 새로고침 했을 때 jwt를 저장하고 있던 변수의 값이 초기화되는 문제가 발생했다.

## 작업 사항

- refresh token을 이용해 jwt를 재발급 받는 로직 구현

### jwt를 지역 변수에 저장하는 이유

localStorage, sessionStorage에 jwt를 저장하여 사용할 수 있었지만, 이 방식을 사용하면 XSS 공격에 취약해진다.
(XSS 공격: 공격자가 악성 스크립트를 주입시켜, 다른 사용자의 컴퓨터에 실행하는 공격)

JS로 접근할 수 없는 httpOnly cookie에 jwt를 저장하기엔, 매 요청마다 자동으로 쿠키가 실려가기 때문에 완전히 안전하다고 볼 수 없다.

따라서 jwt를 지역 변수에서 관리하기로 결정했다.

### jwt를 지역 변수에 저장하므로써 마주친 문제

회원이 새로고침 했을 경우, jwt를 저장하고 있는 변수의 값이 초기화되는 문제가 발생했다.
이미 로그인 한 사용자가 화면을 새로고침 할 때마다, cookie에 저장되어 있는 refresh token을 통해 jwt를 재발급 받도록 구현했다.


## 이슈 번호

close #76 