### PR TITLE
[FE] 피드백 추가 API 로직 수정

### DIFF
--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -133,28 +133,38 @@ export const postFeedback = async ({
   content,
   labelId,
   resumePage,
+  jwt,
 }: {
   resumeId: number;
   content: string;
   labelId?: number;
   resumePage: number;
+  jwt: string;
 }) => {
-  const formData = new FormData();
-  formData.append('content', content);
-  formData.append('resumePage', String(resumePage));
-  if (labelId) formData.append('labelId', String(labelId));
+  const newFeedback: {
+    content: string;
+    resumePage: number;
+    labelId?: number;
+  } = {
+    content,
+    resumePage,
+  };
+  if (labelId) newFeedback['labelId'] = labelId;
 
-  // todo: request headers에 authorization 추가하기
   const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/feedback`, {
     method: 'POST',
-    body: formData,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
+    body: JSON.stringify(newFeedback),
   });
 
   if (!response.ok) {
     throw response;
   }
 
-  const { data } = await response.json();
+  const { data }: ApiResponse<null> = await response.json();
 
   return data;
 };

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -108,9 +108,9 @@ const ResumeDetail = () => {
   const handleFormSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (currentTab === 'feedback') {
-      if (!comment) return;
+    if (!comment) return;
 
+    if (currentTab === 'feedback') {
       addFeedback({
         resumeId: Number(resumeId),
         content: comment,
@@ -118,8 +118,6 @@ const ResumeDetail = () => {
         resumePage: currentPageNum,
       });
     } else if (currentTab === 'question') {
-      if (!comment) return;
-
       mutateAboutQuestion({
         resumeId: Number(resumeId),
         content: comment,
@@ -128,8 +126,6 @@ const ResumeDetail = () => {
         resumePage: currentPageNum,
       });
     } else if (currentTab === 'comment') {
-      if (!comment) return;
-
       mutateAboutComment({
         resumeId: Number(resumeId),
         content: comment,

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -84,7 +84,7 @@ const ResumeDetail = () => {
     },
   });
 
-  const { mutate: mutateAboutFeedback } = usePostFeedback();
+  const { mutate: addFeedback } = usePostFeedback();
   const { mutate: mutateAboutQuestion } = usePostQuestion();
   const { mutate: mutateAboutComment } = usePostComment();
 
@@ -111,7 +111,7 @@ const ResumeDetail = () => {
     if (currentTab === 'feedback') {
       if (!comment) return;
 
-      mutateAboutFeedback({
+      addFeedback({
         resumeId: Number(resumeId),
         content: comment,
         labelId,


### PR DESCRIPTION
## 개요

기존에 피드백 form에 대한 정보를 FormData로 body에 담아 요청을 보냈으나, json 형식으로 form에 입력한 값을 보내도록 수정했다.

## 작업 사항

- 피드백 form에 입력한 정보를 json 형태로 body에 담아 요청
- 피드백 추가를 성공했다면, 새 피드백이 반영된 피드백 목록 데이터를 조회하여 업데이트하기

## 이슈 번호

close #82 