### PR TITLE
[FE] 예상 질문 추가 API 로직 수정

### DIFF
--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -168,25 +168,33 @@ export const useQuestionLabelList = ({ resumeId, enabled }: UseQuestionLabelList
 export const postQuestion = async ({
   resumeId,
   content,
-  labelId,
   labelContent,
   resumePage,
+  jwt,
 }: {
   resumeId: number;
   content: string;
-  labelId?: number;
-  labelContent?: string;
+  labelContent: string;
   resumePage: number;
+  jwt: string;
 }) => {
-  const formData = new FormData();
-  formData.append('content', content);
-  formData.append('resumePage', String(resumePage));
-  if (labelId) formData.append('labelId', String(labelId));
-  if (labelContent) formData.append('labelContent', labelContent);
+  const newQuestion: {
+    content: string;
+    resumePage: number;
+    labelContent: string;
+  } = {
+    content,
+    resumePage,
+    labelContent,
+  };
 
   const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question`, {
     method: 'POST',
-    body: formData,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
+    body: JSON.stringify(newQuestion),
   });
 
   if (!response.ok) {

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 
@@ -25,6 +25,7 @@ export interface Question {
 
 type QuestionList = Question[];
 
+// GET 예상질문 목록 조회
 interface GetQuestionList extends PageNationData {
   questions: QuestionList;
 }
@@ -124,6 +125,41 @@ export const useQuestionReplyList = ({ resumeId, questionId, enabled }: UseQuest
 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
+    enabled,
+  });
+};
+
+// GET 예상 질문 라벨 목록 조회
+interface QuestionLabel {
+  id: number;
+  label: string;
+}
+
+interface GetQuestionLabelList {
+  labels: QuestionLabel[];
+}
+
+export const getQuestionLabelList = async ({ resumeId }: { resumeId: number }) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question/label`);
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetQuestionLabelList> = await response.json();
+
+  return data;
+};
+
+interface UseQuestionLabelListProps {
+  resumeId: number;
+  enabled: boolean;
+}
+
+export const useQuestionLabelList = ({ resumeId, enabled }: UseQuestionLabelListProps) => {
+  return useQuery({
+    queryKey: ['questionList', resumeId, 'labelList'],
+    queryFn: () => getQuestionLabelList({ resumeId }),
     enabled,
   });
 };

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -94,7 +94,7 @@ const ResumeDetail = () => {
   });
 
   const { mutate: addFeedback } = usePostFeedback();
-  const { mutate: mutateAboutQuestion } = usePostQuestion();
+  const { mutate: addQuestion } = usePostQuestion();
   const { mutate: mutateAboutComment } = usePostComment();
 
   const textareaPlaceholder = {
@@ -139,7 +139,7 @@ const ResumeDetail = () => {
         },
       );
     } else if (currentTab === 'question') {
-      mutateAboutQuestion({
+      addQuestion({
         resumeId: Number(resumeId),
         content: comment,
         labelId,

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -139,13 +139,27 @@ const ResumeDetail = () => {
         },
       );
     } else if (currentTab === 'question') {
-      addQuestion({
-        resumeId: Number(resumeId),
-        content: comment,
-        labelId,
-        labelContent,
-        resumePage: currentPageNum,
-      });
+      addQuestion(
+        {
+          resumeId: Number(resumeId),
+          content: comment,
+          labelContent: labelContent.trim(),
+          resumePage: currentPageNum,
+          jwt,
+        },
+        {
+          onSuccess: () => {
+            return Promise.all([
+              queryClient.invalidateQueries({
+                queryKey: ['questionList', Number(resumeId), currentPageNum],
+              }),
+              queryClient.invalidateQueries({
+                queryKey: ['questionList', Number(resumeId), 'labelList'],
+              }),
+            ]);
+          },
+        },
+      );
     } else if (currentTab === 'comment') {
       mutateAboutComment({
         resumeId: Number(resumeId),

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -10,7 +10,7 @@ import usePdf from '@hooks/usePdf';
 import { useUserContext } from '@contexts/userContext';
 import { useCommentList, usePostComment } from '@apis/commentApi';
 import { useFeedbackList, usePostFeedback } from '@apis/feedbackApi';
-import { usePostQuestion, useQuestionList } from '@apis/questionApi';
+import { usePostQuestion, useQuestionLabelList, useQuestionList } from '@apis/questionApi';
 import { useResumeDetail } from '@apis/resumeApi';
 import { useLabelList } from '@apis/utilApi';
 import {
@@ -86,6 +86,11 @@ const ResumeDetail = () => {
     options: {
       threshold: 0.5,
     },
+  });
+
+  const { data: questionLabelList } = useQuestionLabelList({
+    resumeId: Number(resumeId),
+    enabled: currentTab === 'question',
   });
 
   const { mutate: addFeedback } = usePostFeedback();


### PR DESCRIPTION
## 개요

기존에 예상 질문 form에 대한 정보를 FormData로 body에 담아 요청을 보냈으나, json 형식으로 form에 입력한 값을 보내도록 수정했다.

## 작업 사항

- 예상 질문 form에 입력한 정보를 json 형태로 body에 담아 요청
  - 예상 질문 추가 요청을 보내는 함수의 parameter에 labelId 제거
- 예상 질문 추가를 성공했다면, 새 데이터가 반영된 예상 질문 목록 데이터와 예상 질문 라벨 목록을 조회하여 업데이트
- 예상 질문 라벨 목록 조회 API 로직 구현


## 이슈 번호

close #84 