### PR TITLE
[FE] 댓글 추가 요청 API 로직 수정

### DIFF
--- a/src/apis/commentApi.ts
+++ b/src/apis/commentApi.ts
@@ -56,21 +56,31 @@ export const useCommentList = ({ resumeId, enabled }: UseCommentListProps) => {
 };
 
 // POST 댓글 추가
-export const postComment = async ({ resumeId, content }: { resumeId: number; content: string }) => {
-  const formData = new FormData();
-  formData.append('content', content);
+export const postComment = async ({
+  resumeId,
+  content,
+  jwt,
+}: {
+  resumeId: number;
+  content: string;
+  jwt: string;
+}) => {
+  const newComment: { content: string } = { content };
 
-  // todo: request headers에 authorization 추가하기
   const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/comment`, {
     method: 'POST',
-    body: formData,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
+    body: JSON.stringify(newComment),
   });
 
   if (!response.ok) {
     throw response;
   }
 
-  const { data } = await response.json();
+  const { data }: ApiResponse<null> = await response.json();
 
   return data;
 };

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -95,7 +95,7 @@ const ResumeDetail = () => {
 
   const { mutate: addFeedback } = usePostFeedback();
   const { mutate: addQuestion } = usePostQuestion();
-  const { mutate: mutateAboutComment } = usePostComment();
+  const { mutate: addComment } = usePostComment();
 
   const textareaPlaceholder = {
     feedback: '피드백',
@@ -161,10 +161,20 @@ const ResumeDetail = () => {
         },
       );
     } else if (currentTab === 'comment') {
-      mutateAboutComment({
-        resumeId: Number(resumeId),
-        content: comment,
-      });
+      addComment(
+        {
+          resumeId: Number(resumeId),
+          content: comment,
+          jwt,
+        },
+        {
+          onSuccess: () => {
+            return queryClient.invalidateQueries({
+              queryKey: ['commentList', Number(resumeId)],
+            });
+          },
+        },
+      );
     }
 
     resetForm();


### PR DESCRIPTION
## 개요

기존에 댓글 form에 대한 정보를 FormData로 body에 담아 요청을 보냈으나, json 형식으로 form에 입력한 값을 보내도록 수정했다.

## 작업 사항

- 댓글 form에 입력한 정보를 json 형태로 body에 담아 요청
- 댓글 추가를 성공했다면, 새 데이터가 반영된 댓글 목록 데이터를 조회하여 업데이트

## 이슈 번호

close #87 