### PR TITLE
[FE] 대댓글 추가 기능 구현 및 예상 질문 대댓글에 이모지 클릭 시 표시되는 기능 구현

### DIFF
--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -102,13 +102,23 @@ export const getFeedbackReplyList = async ({
   resumeId,
   parentFeedbackId,
   pageParam,
+  jwt,
 }: {
   resumeId: number;
   parentFeedbackId: number;
   pageParam: number;
+  jwt?: string;
 }) => {
+  const headers = new Headers();
+  if (jwt) headers.append('Authorization', `Bearer ${jwt}`);
+
+  const requestOptions: RequestInit = {
+    headers,
+  };
+
   const response = await fetch(
     `${REQUEST_URL.RESUME}/${resumeId}/feedback/${parentFeedbackId}?page=${pageParam}`,
+    requestOptions,
   );
 
   if (!response.ok) {
@@ -124,13 +134,19 @@ interface UseFeedbackReplyListProps {
   resumeId: number;
   parentFeedbackId: number;
   enabled: boolean;
+  jwt?: string;
 }
 
-export const useFeedbackReplyList = ({ resumeId, parentFeedbackId, enabled }: UseFeedbackReplyListProps) => {
+export const useFeedbackReplyList = ({
+  resumeId,
+  parentFeedbackId,
+  enabled,
+  jwt,
+}: UseFeedbackReplyListProps) => {
   return useInfiniteQuery({
     queryKey: ['feedbackReplyList', resumeId, parentFeedbackId],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getFeedbackReplyList({ resumeId, parentFeedbackId, pageParam }),
+    queryFn: ({ pageParam }) => getFeedbackReplyList({ resumeId, parentFeedbackId, pageParam, jwt }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -96,7 +96,7 @@ interface QuestionReply {
   myEmojiId: number | null;
 }
 
-interface GetQuestionReplyList extends PageNationData {
+export interface GetQuestionReplyList extends PageNationData {
   questionComments: QuestionReply[];
 }
 
@@ -104,13 +104,23 @@ export const getQuestionReplyList = async ({
   resumeId,
   parentQuestionId,
   pageParam,
+  jwt,
 }: {
   resumeId: number;
   parentQuestionId: number;
   pageParam: number;
+  jwt?: string;
 }) => {
+  const headers = new Headers();
+  if (jwt) headers.append('Authorization', `Bearer ${jwt}`);
+
+  const requestOptions: RequestInit = {
+    headers,
+  };
+
   const response = await fetch(
     `${REQUEST_URL.RESUME}/${resumeId}/question/${parentQuestionId}?page=${pageParam}`,
+    requestOptions,
   );
 
   if (!response.ok) {
@@ -126,13 +136,19 @@ interface UseQuestionReplyListProps {
   resumeId: number;
   parentQuestionId: number;
   enabled: boolean;
+  jwt?: string;
 }
 
-export const useQuestionReplyList = ({ resumeId, parentQuestionId, enabled }: UseQuestionReplyListProps) => {
+export const useQuestionReplyList = ({
+  resumeId,
+  parentQuestionId,
+  enabled,
+  jwt,
+}: UseQuestionReplyListProps) => {
   return useInfiniteQuery({
     queryKey: ['questionReplyList', resumeId, parentQuestionId],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getQuestionReplyList({ resumeId, parentQuestionId, pageParam }),
+    queryFn: ({ pageParam }) => getQuestionReplyList({ resumeId, parentQuestionId, pageParam, jwt }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -84,7 +84,7 @@ export const useQuestionList = ({ resumeId, resumePage, enabled, jwt }: UseQuest
 };
 
 // GET 예상질문에 달린 댓글 조회
-interface QuestionReply {
+export interface QuestionReply {
   id: number;
   parentQuestionId: number;
   content: string;

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 
@@ -154,41 +154,6 @@ export const useQuestionReplyList = ({
 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
-    enabled,
-  });
-};
-
-// GET 예상 질문 라벨 목록 조회
-interface QuestionLabel {
-  id: number;
-  label: string;
-}
-
-interface GetQuestionLabelList {
-  labels: QuestionLabel[];
-}
-
-export const getQuestionLabelList = async ({ resumeId }: { resumeId: number }) => {
-  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question/label`);
-
-  if (!response.ok) {
-    throw response;
-  }
-
-  const { data }: ApiResponse<GetQuestionLabelList> = await response.json();
-
-  return data;
-};
-
-interface UseQuestionLabelListProps {
-  resumeId: number;
-  enabled: boolean;
-}
-
-export const useQuestionLabelList = ({ resumeId, enabled }: UseQuestionLabelListProps) => {
-  return useQuery({
-    queryKey: ['questionList', resumeId, 'labelList'],
-    queryFn: () => getQuestionLabelList({ resumeId }),
     enabled,
   });
 };

--- a/src/components/ReplyList/index.tsx
+++ b/src/components/ReplyList/index.tsx
@@ -14,10 +14,14 @@ interface Props {
 }
 
 const ReplyList = ({ type, parentId, resumeId }: Props) => {
+  const { jwt, isLoggedIn } = useUserContext();
+  const isAuthenticated = jwt && isLoggedIn;
+
   const { data: feedbackReplyList, fetchNextPage: fetchNextFeedbackReplyList } = useFeedbackReplyList({
     resumeId,
     parentFeedbackId: parentId,
     enabled: type === 'feedback',
+    jwt,
   });
   const { data: questionReplyList, fetchNextPage: fetchNextQuestionReplyList } = useQuestionReplyList({
     resumeId,
@@ -33,9 +37,6 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
       threshold: 0.5,
     },
   });
-
-  const { jwt, isLoggedIn } = useUserContext();
-  const isAuthenticated = jwt && isLoggedIn;
 
   const [content, setContent] = useState<string>('');
   const { mutate: addFeedbackReply } = usePostFeedbackReply({ resumeId, parentId });

--- a/src/components/ReplyList/index.tsx
+++ b/src/components/ReplyList/index.tsx
@@ -4,7 +4,7 @@ import Reply, { ReplyType } from '@components/Comment/Reply';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import { useUserContext } from '@contexts/userContext';
 import { useFeedbackReplyList, usePostFeedbackReply } from '@apis/feedbackApi';
-import { useQuestionReplyList } from '@apis/questionApi';
+import { usePostQuestionReply, useQuestionReplyList } from '@apis/questionApi';
 import { ReplyForm, ReplyListLayout } from './style';
 
 interface Props {
@@ -40,6 +40,7 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
 
   const [content, setContent] = useState<string>('');
   const { mutate: addFeedbackReply } = usePostFeedbackReply({ resumeId, parentId });
+  const { mutate: addQuestionReply } = usePostQuestionReply({ resumeId, parentId });
 
   let replies: ReplyType[] = [];
 
@@ -65,6 +66,7 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
     if (content.length === 0) return;
 
     if (type === 'feedback') addFeedbackReply({ resumeId, parentFeedbackId: parentId, content, jwt });
+    else if (type === 'question') addQuestionReply({ resumeId, parentQuestionId: parentId, content, jwt });
 
     resetForm();
   };

--- a/src/components/ReplyList/index.tsx
+++ b/src/components/ReplyList/index.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { FormEvent, useState } from 'react';
 import { Button, Textarea } from 'review-me-design-system';
 import Reply, { ReplyType } from '@components/Comment/Reply';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
-import { useFeedbackReplyList } from '@apis/feedbackApi';
+import { useUserContext } from '@contexts/userContext';
+import { useFeedbackReplyList, usePostFeedbackReply } from '@apis/feedbackApi';
 import { useQuestionReplyList } from '@apis/questionApi';
 import { ReplyForm, ReplyListLayout } from './style';
 
@@ -33,6 +34,12 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
     },
   });
 
+  const { jwt, isLoggedIn } = useUserContext();
+  const isAuthenticated = jwt && isLoggedIn;
+
+  const [content, setContent] = useState<string>('');
+  const { mutate: addFeedbackReply } = usePostFeedbackReply({ resumeId, parentId });
+
   let replies: ReplyType[] = [];
 
   if (type === 'feedback' && feedbackReplyList)
@@ -46,6 +53,21 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
       .flat()
       .map((reply) => ({ ...reply, parentId: reply.parentQuestionId }));
 
+  const resetForm = () => {
+    setContent('');
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!isAuthenticated) return;
+    if (content.length === 0) return;
+
+    if (type === 'feedback') addFeedbackReply({ resumeId, parentFeedbackId: parentId, content, jwt });
+
+    resetForm();
+  };
+
   return (
     <ReplyListLayout>
       <ul>
@@ -56,8 +78,8 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
         ))}
         <div ref={setTarget}></div>
       </ul>
-      <ReplyForm>
-        <Textarea placeholder="댓글" />
+      <ReplyForm onSubmit={handleSubmit}>
+        <Textarea value={content} onChange={(e) => setContent(e.target.value)} />
         <Button variant="default" size="s">
           작성
         </Button>

--- a/src/components/ReplyList/index.tsx
+++ b/src/components/ReplyList/index.tsx
@@ -27,6 +27,7 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
     resumeId,
     parentQuestionId: parentId,
     enabled: type === 'question',
+    jwt,
   });
   const { setTarget } = useIntersectionObserver({
     onIntersect: () => {

--- a/src/components/TokenRefresh/index.tsx
+++ b/src/components/TokenRefresh/index.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import useAuth from '@hooks/useAuth';
 import { useUserContext } from '@contexts/userContext';
+import { ROUTE_PATH } from '@constants';
 
 interface Props {
   children: React.ReactNode;
@@ -8,8 +10,9 @@ interface Props {
 
 const TokenRefresh = ({ children }: Props) => {
   const { getRenewedJwtQuery } = useAuth();
-  const { isSuccess, refetch, isFetched, data, isError, status } = getRenewedJwtQuery;
-  const { login, logout, isLoggedIn } = useUserContext();
+  const { isSuccess, refetch, isFetched, data, isError, status, error } = getRenewedJwtQuery;
+  const { login, logout, isLoggedIn, jwt } = useUserContext();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const shouldRefreshJwt = isLoggedIn;
@@ -29,10 +32,12 @@ const TokenRefresh = ({ children }: Props) => {
     }
     if (isJwtRenewalFailed) {
       logout();
+      alert(error?.message);
+      navigate(ROUTE_PATH.ROOT);
     }
-  }, [isSuccess, isFetched, data, isLoggedIn]);
+  }, [isSuccess, isError, isFetched, data, isLoggedIn]);
 
-  const isRenewedJwtNotReceived = status === 'pending' && isLoggedIn;
+  const isRenewedJwtNotReceived = isLoggedIn && !jwt;
 
   if (isRenewedJwtNotReceived) {
     return <></>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,15 +7,18 @@ import { ReviewMeProvider } from 'review-me-design-system';
 import { GlobalStyle } from '@styles/GlobalStyle';
 import router from './router';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+    },
+    mutations: {
+      retry: 1,
+    },
+  },
+});
 
 const main = async () => {
-  if (process.env.NODE_ENV === 'development') {
-    const { worker } = await import('./mocks/browser');
-
-    await worker.start();
-  }
-
   createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -61,11 +61,7 @@ const ResumeDetail = () => {
     ? currentTab === 'feedback' && !!jwt
     : currentTab === 'feedback';
 
-  const {
-    data: feedbackListData,
-    refetch: refetchFeedbackList,
-    fetchNextPage: fetchNextPageAboutFeedback,
-  } = useFeedbackList({
+  const { data: feedbackListData, fetchNextPage: fetchNextPageAboutFeedback } = useFeedbackList({
     resumeId: Number(resumeId),
     resumePage: currentPageNum,
     enabled: enabledAboutFeedbackList,
@@ -82,12 +78,6 @@ const ResumeDetail = () => {
     enabled: currentTab === 'comment',
     jwt,
   });
-
-  useEffect(() => {
-    if (jwt && currentTab === 'feedback') {
-      refetchFeedbackList();
-    }
-  }, [jwt, currentTab]);
 
   const feedbackList = feedbackListData?.pages.map((page) => page.feedbacks).flat();
   const questionList = questionListData?.pages.map((page) => page.questions).flat();

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -10,7 +10,7 @@ import usePdf from '@hooks/usePdf';
 import { useUserContext } from '@contexts/userContext';
 import { useCommentList, usePostComment } from '@apis/commentApi';
 import { useFeedbackList, usePostFeedback } from '@apis/feedbackApi';
-import { usePostQuestion, useQuestionLabelList, useQuestionList } from '@apis/questionApi';
+import { usePostQuestion, useQuestionList } from '@apis/questionApi';
 import { useResumeDetail } from '@apis/resumeApi';
 import { useLabelList } from '@apis/utilApi';
 import {
@@ -102,11 +102,6 @@ const ResumeDetail = () => {
     options: {
       threshold: 0.5,
     },
-  });
-
-  const { data: questionLabelList } = useQuestionLabelList({
-    resumeId: Number(resumeId),
-    enabled: currentTab === 'question',
   });
 
   const { mutate: addFeedback } = usePostFeedback();


### PR DESCRIPTION
## 개요

피드백 대댓글과 예상질문 대댓글 추가하여 새로운 목록 데이터를 화면에 보일 수 있도록 구현했다.
하지만, 가끔 목록에 새로 추가된 데이터가 반영되지 않는 문제가 있으나 원인을 찾지 못했다.

## 작업 사항

- 피드백 대댓글 추가

https://github.com/review-me-Team/review-me-fe/assets/96980857/837c1c3a-110f-429a-bc12-973c4e7dca33

- 예상 질문 대댓글 추가

https://github.com/review-me-Team/review-me-fe/assets/96980857/c167149b-d100-4266-95b2-f484f041d582

- queryClient의 defaultOptions 설정
- 예상 질문 대댓글에 이모지 클릭시 표시



## 이슈 번호

close #91 