### PR TITLE
[FE] 내 이력서 목록 조회 API

### DIFF
--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -46,6 +46,55 @@ export const useResumeList = () => {
   });
 };
 
+// GET 내 이력서 목록 조회
+export interface MyResume {
+  id: number;
+  title: string;
+  createdAt: string;
+  scope: string;
+  occupation: string;
+  year: number;
+}
+
+interface GetMyResumeList extends PageNationData {
+  resumes: MyResume[];
+}
+
+// ! jwt가 없을 경우 401 에러 발생 (custom hook을 최상단에서 호출해야 하기 때문에 undefined도 허용)
+export const getMyResumeList = async ({ pageParam, jwt }: { pageParam: number; jwt?: string }) => {
+  const response = await fetch(`${REQUEST_URL.MY_RESUME}?page=${pageParam}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetMyResumeList> = await response.json();
+
+  return data;
+};
+
+interface UseMyResumeListProps {
+  jwt?: string;
+}
+
+export const useMyResumeList = ({ jwt }: UseMyResumeListProps) => {
+  return useInfiniteQuery({
+    queryKey: ['myResumeList'],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getMyResumeList({ pageParam, jwt }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+  });
+};
+
 // GET 이력서 상세 조회
 interface GetResumeDetail {
   resumeUrl: string;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,6 +13,7 @@ const BASE_URL = process.env.BASE_URL;
 export const REQUEST_URL = {
   FRIEND: `${BASE_URL}/friend`,
   RESUME: `${BASE_URL}/resume`,
+  MY_RESUME: `${BASE_URL}/resume/my`,
   LABEL: `${BASE_URL}/label`,
   OCCUPATION: `${BASE_URL}/occupation`,
   EMOJI: `${BASE_URL}/emoji`,

--- a/src/pages/MyResume/index.tsx
+++ b/src/pages/MyResume/index.tsx
@@ -2,11 +2,18 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from 'review-me-design-system';
 import MyResumeItem from '@components/MyResumeItem';
+import { useUserContext } from '@contexts/userContext';
+import { useMyResumeList } from '@apis/resumeApi';
 import { ROUTE_PATH } from '@constants';
 import { Main, MyResumeList } from './style';
 
 const MyResume = () => {
   const navigate = useNavigate();
+  const { jwt } = useUserContext();
+
+  const { data: myResumeListData } = useMyResumeList({ jwt });
+
+  const myResumeList = myResumeListData?.pages.map((page) => page.resumes).flat() ?? [];
 
   return (
     <Main>
@@ -15,46 +22,9 @@ const MyResume = () => {
       </Button>
 
       <MyResumeList>
-        <MyResumeItem
-          id={1}
-          title="이력서 제목"
-          year={0}
-          occupation="backend"
-          scope="전체 공개"
-          createdAt="2023-12-22 15:16:42"
-        />
-        <MyResumeItem
-          id={2}
-          title="이력서 제목"
-          year={0}
-          occupation="backend"
-          scope="전체 공개"
-          createdAt="2023-12-22 15:16:42"
-        />
-        <MyResumeItem
-          id={3}
-          title="이력서 제목"
-          year={0}
-          occupation="backend"
-          scope="전체 공개"
-          createdAt="2023-12-22 15:16:42"
-        />
-        <MyResumeItem
-          id={4}
-          title="이력서 제목"
-          year={0}
-          occupation="backend"
-          scope="전체 공개"
-          createdAt="2023-12-22 15:16:42"
-        />
-        <MyResumeItem
-          id={5}
-          title="이력서 제목"
-          year={0}
-          occupation="backend"
-          scope="전체 공개"
-          createdAt="2023-12-22 15:16:42"
-        />
+        {myResumeList.map((resume) => {
+          return <MyResumeItem key={resume.id} {...resume} />;
+        })}
       </MyResumeList>
     </Main>
   );


### PR DESCRIPTION
## 개요

이력서 목록 조회를 위한 API 요청 로직을 구현했다.

## 작업 사항

- 이력서 목록 조회 요청하는 custom hook 생성
  - 이때 parameter로 `jwt`의 type을 `string | undefined`로 설정했음 (이유: 최상단에 hook을 호출해야 하므로)
  - 만약 `jwt`가 `undefined`라면 서버에서 응답 코드로 401이 올 것
- `My 이력서` 페이지에 내 이력서 목록 조회 요청을 보내고, 응답 온 데이터를 화면에 표시

## 이슈 번호

close #105 