### PR TITLE
[FE] 내 이력서 아이템 컴포넌트의 스타일 수정 및 기능 구현

### DIFF
--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 
@@ -170,6 +170,35 @@ export const postResume = async ({
 
 export const usePostResume = () => {
   return useMutation({ mutationFn: postResume });
+};
+
+// DELETE 이력서 삭제
+export const deleteResume = async ({ resumeId, jwt }: { resumeId: number; jwt: string }) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const useDeleteResume = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteResume,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myResumeList'] });
+    },
+  });
 };
 
 // PATCH 이력서 수정

--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -105,8 +105,15 @@ interface GetResumeDetail {
   year: number;
 }
 
-export const getResumeDetail = async (resumeId: number) => {
-  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}`);
+export const getResumeDetail = async ({ resumeId, jwt }: { resumeId: number; jwt?: string }) => {
+  const headers = new Headers();
+  if (jwt) headers.append('Authorization', `Bearer ${jwt}`);
+
+  const requestOptions: RequestInit = {
+    headers,
+  };
+
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}`, requestOptions);
 
   if (!response.ok) {
     throw response;
@@ -117,8 +124,8 @@ export const getResumeDetail = async (resumeId: number) => {
   return data;
 };
 
-export const useResumeDetail = (resumeId: number) => {
-  return useQuery({ queryKey: ['resume', resumeId], queryFn: () => getResumeDetail(resumeId) });
+export const useResumeDetail = ({ resumeId, jwt }: { resumeId: number; jwt?: string }) => {
+  return useQuery({ queryKey: ['resume', resumeId], queryFn: () => getResumeDetail({ resumeId, jwt }) });
 };
 
 // POST 이력서 업로드

--- a/src/components/Modal/ResumeDeleteModal/index.tsx
+++ b/src/components/Modal/ResumeDeleteModal/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Button, Modal } from 'review-me-design-system';
+import { useUserContext } from '@contexts/userContext';
+import { useDeleteResume } from '@apis/resumeApi';
 import { ButtonsContainer, Description } from './style';
 
 interface Props {
@@ -9,6 +11,9 @@ interface Props {
 }
 
 const ResumeDeleteModal = ({ resumeId, isOpen, onClose }: Props) => {
+  const { jwt } = useUserContext();
+  const { mutate: deleteResume } = useDeleteResume();
+
   return (
     <Modal modalRootId="modal-root" isOpen={isOpen} onClose={onClose} width="18.75rem">
       <Description>
@@ -24,7 +29,7 @@ const ResumeDeleteModal = ({ resumeId, isOpen, onClose }: Props) => {
           size="m"
           width="100%"
           onClick={() => {
-            console.log(resumeId); // * test
+            if (jwt) deleteResume({ resumeId, jwt });
             onClose();
           }}
         >

--- a/src/components/MyResumeItem/index.tsx
+++ b/src/components/MyResumeItem/index.tsx
@@ -12,6 +12,7 @@ import {
   MyResumeItemLayout,
   Title,
   Scope,
+  CreatedAt,
 } from './style';
 
 interface Props {
@@ -35,7 +36,7 @@ const MyResumeItem = ({ id, title, year, occupation, scope, createdAt }: Props) 
           <Scope>{scope}</Scope>
           <Occupation>직군: {occupation}</Occupation>
           <span>경력: {year > 0 ? `${year}년차` : '신입'}</span>
-          <span>{formatDate(createdAt)}</span>
+          <CreatedAt>{formatDate(createdAt)}</CreatedAt>
         </DescriptionContainer>
       </Link>
       <ButtonsContainer>

--- a/src/components/MyResumeItem/index.tsx
+++ b/src/components/MyResumeItem/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useModal } from 'review-me-design-system';
 import ResumeDeleteModal from '@components/Modal/ResumeDeleteModal';
 import { ROUTE_PATH } from '@constants';
@@ -28,13 +28,15 @@ const MyResumeItem = ({ id, title, year, occupation, scope, createdAt }: Props) 
 
   return (
     <MyResumeItemLayout>
-      <Title>{title}</Title>
-      <DescriptionContainer>
-        <Occupation>직군: {occupation}</Occupation>
-        <span>경력: {year > 0 ? `${year}년차` : '신입'}</span>
-        <span>{scope}</span>
-        <span>{formatDate(createdAt)}</span>
-      </DescriptionContainer>
+      <Link to={`${ROUTE_PATH.RESUME}/${id}`}>
+        <Title>{title}</Title>
+        <DescriptionContainer>
+          <Occupation>직군: {occupation}</Occupation>
+          <span>경력: {year > 0 ? `${year}년차` : '신입'}</span>
+          <span>{scope}</span>
+          <span>{formatDate(createdAt)}</span>
+        </DescriptionContainer>
+      </Link>
       <ButtonsContainer>
         <Button
           $position="left"

--- a/src/components/MyResumeItem/index.tsx
+++ b/src/components/MyResumeItem/index.tsx
@@ -11,6 +11,7 @@ import {
   DescriptionContainer,
   MyResumeItemLayout,
   Title,
+  Scope,
 } from './style';
 
 interface Props {
@@ -31,9 +32,9 @@ const MyResumeItem = ({ id, title, year, occupation, scope, createdAt }: Props) 
       <Link to={`${ROUTE_PATH.RESUME}/${id}`}>
         <Title>{title}</Title>
         <DescriptionContainer>
+          <Scope>{scope}</Scope>
           <Occupation>직군: {occupation}</Occupation>
           <span>경력: {year > 0 ? `${year}년차` : '신입'}</span>
-          <span>{scope}</span>
           <span>{formatDate(createdAt)}</span>
         </DescriptionContainer>
       </Link>

--- a/src/components/MyResumeItem/style.ts
+++ b/src/components/MyResumeItem/style.ts
@@ -43,6 +43,10 @@ const Scope = styled.div`
   border-radius: 0.5rem;
 `;
 
+const CreatedAt = styled.span`
+  color: ${theme.palette.grey500};
+`;
+
 const ButtonsContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -80,4 +84,13 @@ const Button = styled.button<{ $position: 'left' | 'right' }>`
   }
 `;
 
-export { MyResumeItemLayout, DescriptionContainer, Title, Occupation, Scope, ButtonsContainer, Button };
+export {
+  MyResumeItemLayout,
+  DescriptionContainer,
+  Title,
+  Occupation,
+  Scope,
+  CreatedAt,
+  ButtonsContainer,
+  Button,
+};

--- a/src/components/MyResumeItem/style.ts
+++ b/src/components/MyResumeItem/style.ts
@@ -1,5 +1,6 @@
 import { theme } from 'review-me-design-system';
 import styled, { css } from 'styled-components';
+import { ellipsisStyles } from '@styles/common';
 
 const MyResumeItemLayout = styled.div`
   display: flex;
@@ -23,14 +24,8 @@ const DescriptionContainer = styled.div`
   margin-top: 0.5rem;
 `;
 
-const ellipsisStyles = css`
-  overflow-x: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  word-break: break-all;
-`;
-
 const Title = styled.span`
+  display: block;
   ${theme.font.title.default}
   ${ellipsisStyles}
 `;

--- a/src/components/MyResumeItem/style.ts
+++ b/src/components/MyResumeItem/style.ts
@@ -34,6 +34,15 @@ const Occupation = styled.span`
   ${ellipsisStyles}
 `;
 
+const Scope = styled.div`
+  width: fit-content;
+  padding: 0 0.5rem;
+  margin-bottom: 0.5rem;
+
+  background-color: ${theme.palette.green200};
+  border-radius: 0.5rem;
+`;
+
 const ButtonsContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -71,4 +80,4 @@ const Button = styled.button<{ $position: 'left' | 'right' }>`
   }
 `;
 
-export { MyResumeItemLayout, DescriptionContainer, Title, Occupation, ButtonsContainer, Button };
+export { MyResumeItemLayout, DescriptionContainer, Title, Occupation, Scope, ButtonsContainer, Button };

--- a/src/components/MyResumeItem/style.ts
+++ b/src/components/MyResumeItem/style.ts
@@ -8,7 +8,8 @@ const MyResumeItemLayout = styled.li`
   padding: 1rem;
 
   background-color: ${theme.color.neutral.bg.default};
-  border: 1px solid ${theme.color.accent.bd.strong};
+  border-radius: 1rem;
+  box-shadow: 0 0 1.5rem -0.25rem rgba(16, 24, 40, 0.08);
 
   color: ${theme.color.accent.text.strong};
   ${theme.font.body.default};
@@ -44,10 +45,16 @@ const ButtonsContainer = styled.div`
   align-items: center;
 
   border: 1px solid ${theme.color.accent.bd.strong};
+  border-radius: 1rem;
 `;
 
 const leftButtonStyles = css`
   border-right: 1px solid ${theme.color.accent.bd.strong};
+  border-radius: 1rem 0 0 1rem;
+`;
+
+const rightButtonStyles = css`
+  border-radius: 0 1rem 1rem 0;
 `;
 
 const Button = styled.button<{ $position: 'left' | 'right' }>`
@@ -56,13 +63,17 @@ const Button = styled.button<{ $position: 'left' | 'right' }>`
   align-items: center;
   width: 100%;
   height: 2.75rem;
-  ${({ $position }) => $position === 'left' && leftButtonStyles}
+  ${({ $position }) => ($position === 'left' ? leftButtonStyles : rightButtonStyles)}
 
-  background-color: ${theme.color.neutral.bg.default};
+  background-color: transparent;
 
   color: ${theme.color.accent.text.strong};
 
   cursor: pointer;
+
+  &:hover {
+    background-color: ${theme.palette.green100};
+  }
 `;
 
 export { MyResumeItemLayout, DescriptionContainer, Title, Occupation, ButtonsContainer, Button };

--- a/src/components/MyResumeItem/style.ts
+++ b/src/components/MyResumeItem/style.ts
@@ -12,7 +12,7 @@ const MyResumeItemLayout = styled.div`
   border-radius: 1rem;
   box-shadow: 0 0 1.5rem -0.25rem rgba(16, 24, 40, 0.08);
 
-  color: ${theme.color.accent.text.strong};
+  color: ${theme.color.neutral.text.default};
   ${theme.font.body.default};
 
   cursor: pointer;
@@ -39,12 +39,12 @@ const ButtonsContainer = styled.div`
   justify-content: center;
   align-items: center;
 
-  border: 1px solid ${theme.color.accent.bd.strong};
+  border: 1px solid ${theme.color.accent.bd.weak};
   border-radius: 1rem;
 `;
 
 const leftButtonStyles = css`
-  border-right: 1px solid ${theme.color.accent.bd.strong};
+  border-right: 1px solid ${theme.color.accent.bd.weak};
   border-radius: 1rem 0 0 1rem;
 `;
 

--- a/src/components/MyResumeItem/style.ts
+++ b/src/components/MyResumeItem/style.ts
@@ -1,7 +1,7 @@
 import { theme } from 'review-me-design-system';
 import styled, { css } from 'styled-components';
 
-const MyResumeItemLayout = styled.li`
+const MyResumeItemLayout = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -20,7 +20,7 @@ const MyResumeItemLayout = styled.li`
 const DescriptionContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  margin-top: 0.5rem;
 `;
 
 const ellipsisStyles = css`

--- a/src/pages/MyResume/index.tsx
+++ b/src/pages/MyResume/index.tsx
@@ -4,6 +4,7 @@ import { Button } from 'review-me-design-system';
 import MyResumeItem from '@components/MyResumeItem';
 import { useUserContext } from '@contexts/userContext';
 import { useMyResumeList } from '@apis/resumeApi';
+import { PageMain } from '@styles/common';
 import { ROUTE_PATH } from '@constants';
 import { Main, MyResumeList } from './style';
 
@@ -16,7 +17,7 @@ const MyResume = () => {
   const myResumeList = myResumeListData?.pages.map((page) => page.resumes).flat() ?? [];
 
   return (
-    <Main>
+    <PageMain>
       <Button variant="default" size="m" onClick={() => navigate(ROUTE_PATH.RESUME_UPLOAD)}>
         이력서 pdf 올리기
       </Button>
@@ -30,7 +31,7 @@ const MyResume = () => {
           );
         })}
       </MyResumeList>
-    </Main>
+    </PageMain>
   );
 };
 

--- a/src/pages/MyResume/index.tsx
+++ b/src/pages/MyResume/index.tsx
@@ -23,7 +23,11 @@ const MyResume = () => {
 
       <MyResumeList>
         {myResumeList.map((resume) => {
-          return <MyResumeItem key={resume.id} {...resume} />;
+          return (
+            <li key={resume.id}>
+              <MyResumeItem {...resume} />
+            </li>
+          );
         })}
       </MyResumeList>
     </Main>

--- a/src/pages/MyResume/style.ts
+++ b/src/pages/MyResume/style.ts
@@ -23,6 +23,10 @@ const MyResumeList = styled.ul`
   gap: 1.5rem;
   width: 100%;
 
+  @media screen and (max-width: 1280px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.5rem;
+  }
   @media screen and (max-width: 768px) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1rem 0.625rem;

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -41,7 +41,7 @@ const ResumeDetail = () => {
   const { jwt, isLoggedIn } = useUserContext();
   const { resumeId } = useParams();
 
-  const { data: resumeDetail } = useResumeDetail(Number(resumeId));
+  const { data: resumeDetail } = useResumeDetail({ resumeId: Number(resumeId), jwt });
 
   const PDF_BUTTON_ICON_SIZE = 24;
 

--- a/src/pages/ResumeUpdate/index.tsx
+++ b/src/pages/ResumeUpdate/index.tsx
@@ -2,23 +2,25 @@ import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Icon } from 'review-me-design-system';
 import ResumeUpdateForm from '@components/ResumeForm/ResumeUpdateForm';
+import { useUserContext } from '@contexts/userContext';
 import { useResumeDetail, useUpdateResume } from '@apis/resumeApi';
 import { Occupation, Scope, useOccupationList, useScopeList } from '@apis/utilApi';
 import { PageMain } from '@styles/common';
 import { ResumeUploadContainer, IconButton, Description, MainDescription } from './style';
 
 interface Location {
-  state: { id: number; title: string; year: number; occupation: string; scope: string };
+  state: { resumeId: number; title: string; year: number; occupation: string; scope: string };
 }
 
 const ResumeUpdate = () => {
   const {
-    state: { id: resumeId, title: prevTitle, year: prevYear, occupation: prevOccupation, scope: prevScope },
+    state: { resumeId, title: prevTitle, year: prevYear, occupation: prevOccupation, scope: prevScope },
   } = useLocation() as Location;
+  const { jwt } = useUserContext();
 
   const navigate = useNavigate();
 
-  const { data: resumeDetail } = useResumeDetail(resumeId);
+  const { data: resumeDetail } = useResumeDetail({ resumeId, jwt });
   const { data: occupationList } = useOccupationList();
   const { data: scopeList } = useScopeList();
 


### PR DESCRIPTION
## 개요

내 이력서 항목을 나타내는 컴포넌트의 스타일을 수정하고, 기능을 구현할 예정이다.

## 작업 사항

### 스타일 변경

- 수정 / 삭제 버튼을 감싸고 있는 컴포넌트의 border-radius 추가
- 수정 / 삭제 버튼에 hover 스타일 적용
- 이력서 항목 컴포넌트에서 border 제거 및 그림자 효과
- 글씨 색상 변경
- 공개 범위를 나타내는 컴포넌트 생성 
- 이력서 생성 날짜 텍스트 색상 변경
- 내 이력서 페이지 layout 스타일 수정
  - 공통 컴포넌트인 PageMain 적용
  - 768px 초과 1280px 이하일 때 grid 스타일 설정

### 기능

- 내 이력서 삭제 API 로직
- 이력서 상세 조회하는 함수 및 custom hook의 parameter에 jwt 추가
- 이력서 삭제 Modal에서 삭제 버튼을 클릭하면, 이력서 삭제하는 기능 구현


## 이슈 번호

close #104 