### PR TITLE
[FE] 이력서 아이템 스타일 수정

### DIFF
--- a/src/components/ResumeItem/index.tsx
+++ b/src/components/ResumeItem/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ROUTE_PATH } from '@constants';
 import { formatDate } from '@utils';
-import { ResumeItemLayout, Title, User, UserImg, UserInfo } from './style';
+import { CreatedAt, ResumeItemLayout, Title, User, UserImg, UserInfo } from './style';
 
 interface Props {
   id: number;
@@ -25,7 +25,7 @@ const ResumeItem = ({ id, title, writerName, writerProfileUrl, createdAt, occupa
         <span>직군: {occupation}</span>
         <span>경력: {year === 0 ? '신입' : `${year}년차`}</span>
       </UserInfo>
-      <span>{formatDate(createdAt)}</span>
+      <CreatedAt>{formatDate(createdAt)}</CreatedAt>
     </ResumeItemLayout>
   );
 };

--- a/src/components/ResumeItem/style.ts
+++ b/src/components/ResumeItem/style.ts
@@ -13,7 +13,7 @@ const ResumeItemLayout = styled(Link)`
   border-radius: 1rem;
   box-shadow: 0 0 1.5rem -0.25rem rgba(16, 24, 40, 0.08);
 
-  color: ${theme.color.accent.text.strong};
+  color: ${theme.color.neutral.text.default};
   ${theme.font.body.default};
 
   cursor: pointer;

--- a/src/components/ResumeItem/style.ts
+++ b/src/components/ResumeItem/style.ts
@@ -52,4 +52,8 @@ const UserInfo = styled.div`
   }
 `;
 
-export { ResumeItemLayout, Title, User, UserImg, UserInfo };
+const CreatedAt = styled.span`
+  color: ${theme.palette.grey500};
+`;
+
+export { ResumeItemLayout, Title, User, UserImg, UserInfo, CreatedAt };

--- a/src/components/ResumeItem/style.ts
+++ b/src/components/ResumeItem/style.ts
@@ -10,7 +10,8 @@ const ResumeItemLayout = styled(Link)`
   padding: 1rem;
 
   background-color: ${theme.color.neutral.bg.default};
-  border: 1px solid ${theme.color.accent.bd.strong};
+  border-radius: 1rem;
+  box-shadow: 0 0 1.5rem -0.25rem rgba(16, 24, 40, 0.08);
 
   color: ${theme.color.accent.text.strong};
   ${theme.font.body.default};


### PR DESCRIPTION
## 개요

이력서 메인 페이지에 보여줄 이력서 아이템의 스타일을 수정했다.

## 작업 사항

- border 제거
- 그림자 효과
- 텍스트 색상 진한 초록색에서 검정색으로 변경
- 이력서 생성 날짜 텍스트 색상 변경

<img width="306" alt="스크린샷 2024-03-12 오후 4 31 10" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/82c674c3-d36a-48f6-9ca6-704c7e263a94">

## 이슈 번호

close #108 