### PR TITLE
[FE] 피드백 / 예상 질문 / 댓글 / 피드백 대댓글 / 예상 질문 대댓글 삭제 API 요청

### DIFF
--- a/src/apis/commentApi.ts
+++ b/src/apis/commentApi.ts
@@ -105,6 +105,36 @@ export const usePostComment = () => {
   return useMutation({ mutationFn: postComment });
 };
 
+// DELETE 댓글 삭제
+export const deleteComment = async ({
+  resumeId,
+  commentId,
+  jwt,
+}: {
+  resumeId: number;
+  commentId: number;
+  jwt: string;
+}) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/comment/${commentId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const useDeleteComment = () => {
+  return useMutation({ mutationFn: deleteComment });
+};
+
 // PATCH 댓글 이모지 수정
 export const patchEmojiAboutComment = async ({
   resumeId,

--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -202,6 +202,36 @@ export const usePostFeedback = () => {
   return useMutation({ mutationFn: postFeedback });
 };
 
+// DELETE 피드백 삭제
+export const deleteFeedback = async ({
+  resumeId,
+  feedbackId,
+  jwt,
+}: {
+  resumeId: number;
+  feedbackId: number;
+  jwt: string;
+}) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/feedback/${feedbackId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const useDeleteFeedback = () => {
+  return useMutation({ mutationFn: deleteFeedback });
+};
+
 // PATCH 피드백 이모지 수정
 export const patchEmojiAboutFeedback = async ({
   resumeId,

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -204,6 +204,36 @@ export const usePostQuestion = () => {
   return useMutation({ mutationFn: postQuestion });
 };
 
+// DELETE 예상 질문 삭제
+export const deleteQuestion = async ({
+  resumeId,
+  questionId,
+  jwt,
+}: {
+  resumeId: number;
+  questionId: number;
+  jwt: string;
+}) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question/${questionId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const useDeleteQuestion = () => {
+  return useMutation({ mutationFn: deleteQuestion });
+};
+
 // PATCH 예상 질문 이모지 수정
 export const patchEmojiAboutQuestion = async ({
   resumeId,

--- a/src/components/Comment/Reply/index.tsx
+++ b/src/components/Comment/Reply/index.tsx
@@ -1,6 +1,9 @@
 import React, { MouseEvent } from 'react';
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { Icon, Label as EmojiLabel, theme } from 'review-me-design-system';
+import { css } from 'styled-components';
+import Dropdown from '@components/Dropdown';
+import useDropdown from '@hooks/useDropdown';
 import useEmojiUpdate from '@hooks/useEmojiUpdate';
 import useHover from '@hooks/useHover';
 import { useUserContext } from '@contexts/userContext';
@@ -26,6 +29,7 @@ import {
   EmojiLabelItem,
   CommentContent,
   CommentInfo,
+  MoreIconContainer,
 } from '../style';
 
 type Emoji = {
@@ -64,6 +68,7 @@ const Reply = ({
   myEmojiId,
 }: Props) => {
   const { isHover, changeHoverState } = useHover();
+  const { isDropdownOpen, openDropdown, closeDropdown } = useDropdown();
   const { jwt, isLoggedIn, user } = useUserContext();
   const isAuthenticated = jwt && isLoggedIn;
 
@@ -156,9 +161,34 @@ const Reply = ({
         </Info>
 
         {hasMoreIcon && (
-          <IconButton>
-            <Icon iconName="more" width={ICON_SIZE} height={ICON_SIZE} color={theme.color.accent.bg.strong} />
-          </IconButton>
+          <MoreIconContainer>
+            <IconButton onClick={openDropdown}>
+              <Icon
+                iconName="more"
+                width={ICON_SIZE}
+                height={ICON_SIZE}
+                color={theme.color.accent.bg.strong}
+              />
+            </IconButton>
+            <Dropdown
+              isOpen={isDropdownOpen}
+              onClose={closeDropdown}
+              css={css`
+                width: 4rem;
+                top: 1.5rem;
+                right: 0;
+              `}
+            >
+              <Dropdown.DropdownItem>수정</Dropdown.DropdownItem>
+              <Dropdown.DropdownItem
+                $css={css`
+                  color: ${theme.palette.red};
+                `}
+              >
+                삭제
+              </Dropdown.DropdownItem>
+            </Dropdown>
+          </MoreIconContainer>
         )}
       </Top>
 

--- a/src/components/Comment/Reply/index.tsx
+++ b/src/components/Comment/Reply/index.tsx
@@ -161,6 +161,7 @@ const Reply = ({
 
   // 삭제
   const { mutate: deleteFeedback } = useDeleteFeedback();
+  const { mutate: deleteQuestion } = useDeleteQuestion();
 
   const handleDeleteBtnClick = () => {
     if (!jwt) return;
@@ -171,6 +172,16 @@ const Reply = ({
         {
           onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['feedbackReplyList', resumeId, parentId] });
+          },
+        },
+      );
+    }
+    if (type === 'question') {
+      deleteQuestion(
+        { resumeId, questionId: id, jwt },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['questionReplyList', resumeId, parentId] });
           },
         },
       );

--- a/src/components/Comment/Reply/index.tsx
+++ b/src/components/Comment/Reply/index.tsx
@@ -7,8 +7,18 @@ import useDropdown from '@hooks/useDropdown';
 import useEmojiUpdate from '@hooks/useEmojiUpdate';
 import useHover from '@hooks/useHover';
 import { useUserContext } from '@contexts/userContext';
-import { FeedbackReply, GetFeedbackReplyList, usePatchEmojiAboutFeedback } from '@apis/feedbackApi';
-import { GetQuestionReplyList, QuestionReply, usePatchEmojiAboutQuestion } from '@apis/questionApi';
+import {
+  FeedbackReply,
+  GetFeedbackReplyList,
+  useDeleteFeedback,
+  usePatchEmojiAboutFeedback,
+} from '@apis/feedbackApi';
+import {
+  GetQuestionReplyList,
+  QuestionReply,
+  useDeleteQuestion,
+  usePatchEmojiAboutQuestion,
+} from '@apis/questionApi';
 import { useEmojiList } from '@apis/utilApi';
 import { formatDate } from '@utils';
 // * Comment와 동일한 스타일을 공유하기 때문에 styled-components로 만든 공통 컴포넌트를 사용
@@ -149,6 +159,24 @@ const Reply = ({
       );
   };
 
+  // 삭제
+  const { mutate: deleteFeedback } = useDeleteFeedback();
+
+  const handleDeleteBtnClick = () => {
+    if (!jwt) return;
+
+    if (type === 'feedback') {
+      deleteFeedback(
+        { resumeId, feedbackId: id, jwt },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['feedbackReplyList', resumeId, parentId] });
+          },
+        },
+      );
+    }
+  };
+
   return (
     <CommentLayout>
       <Top>
@@ -181,6 +209,7 @@ const Reply = ({
             >
               <Dropdown.DropdownItem>수정</Dropdown.DropdownItem>
               <Dropdown.DropdownItem
+                onClick={handleDeleteBtnClick}
                 $css={css`
                   color: ${theme.palette.red};
                 `}

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -332,7 +332,7 @@ const Comment = ({
 
         <CommentContent>
           {labelContent && <SelectedLabel>{labelContent}</SelectedLabel>}
-          <Content>{content}</Content>
+          <Content>{content ?? '삭제된 댓글입니다.'}</Content>
         </CommentContent>
 
         <Bottom>

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -1,7 +1,10 @@
 import React, { MouseEvent, useState } from 'react';
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { Icon, Label as EmojiLabel, theme } from 'review-me-design-system';
+import { css } from 'styled-components';
+import Dropdown from '@components/Dropdown';
 import ReplyList from '@components/ReplyList';
+import useDropdown from '@hooks/useDropdown';
 import useEmojiUpdate from '@hooks/useEmojiUpdate';
 import useHover from '@hooks/useHover';
 import { useUserContext } from '@contexts/userContext';
@@ -29,6 +32,8 @@ import {
   EmojiLabelItem,
   CommentContent,
   CommentInfo,
+  MoreIconContainer,
+  ButtonsContainer,
 } from './style';
 
 type Emoji = {
@@ -74,6 +79,7 @@ const Comment = ({
   const { jwt, isLoggedIn, user } = useUserContext();
   const isAuthenticated = jwt && isLoggedIn;
   const { isHover, changeHoverState } = useHover();
+  const { isDropdownOpen, openDropdown, closeDropdown } = useDropdown();
   const [isOpenReplyList, setIsOpenReplyList] = useState<boolean>(false);
 
   const ICON_SIZE = 24;
@@ -206,7 +212,7 @@ const Comment = ({
             </CommentInfo>
           </Info>
 
-          <div>
+          <ButtonsContainer>
             {hasBookMarkIcon && (
               <IconButton>
                 {bookmarked ? (
@@ -246,16 +252,36 @@ const Comment = ({
               </IconButton>
             )}
             {hasMoreIcon && (
-              <IconButton>
-                <Icon
-                  iconName="more"
-                  width={ICON_SIZE}
-                  height={ICON_SIZE}
-                  color={theme.color.accent.bg.strong}
-                />
-              </IconButton>
+              <MoreIconContainer>
+                <IconButton onClick={openDropdown}>
+                  <Icon
+                    iconName="more"
+                    width={ICON_SIZE}
+                    height={ICON_SIZE}
+                    color={theme.color.accent.bg.strong}
+                  />
+                </IconButton>
+                <Dropdown
+                  isOpen={isDropdownOpen}
+                  onClose={closeDropdown}
+                  css={css`
+                    width: 4rem;
+                    top: 1.5rem;
+                    right: 0;
+                  `}
+                >
+                  <Dropdown.DropdownItem>수정</Dropdown.DropdownItem>
+                  <Dropdown.DropdownItem
+                    $css={css`
+                      color: ${theme.palette.red};
+                    `}
+                  >
+                    삭제
+                  </Dropdown.DropdownItem>
+                </Dropdown>
+              </MoreIconContainer>
             )}
-          </div>
+          </ButtonsContainer>
         </Top>
 
         <CommentContent>

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -10,7 +10,7 @@ import useHover from '@hooks/useHover';
 import { useUserContext } from '@contexts/userContext';
 import { GetCommentList, usePatchEmojiAboutComment, Comment as CommentType } from '@apis/commentApi';
 import { Feedback, GetFeedbackList, useDeleteFeedback, usePatchEmojiAboutFeedback } from '@apis/feedbackApi';
-import { GetQuestionList, Question, usePatchEmojiAboutQuestion } from '@apis/questionApi';
+import { GetQuestionList, Question, useDeleteQuestion, usePatchEmojiAboutQuestion } from '@apis/questionApi';
 import { useEmojiList } from '@apis/utilApi';
 import { formatDate } from '@utils';
 import {
@@ -202,6 +202,7 @@ const Comment = ({
 
   // 삭제
   const { mutate: deleteFeedback } = useDeleteFeedback();
+  const { mutate: deleteQuestion } = useDeleteQuestion();
 
   const handleDeleteBtnClick = () => {
     if (!jwt) return;
@@ -212,6 +213,16 @@ const Comment = ({
         {
           onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['feedbackList', resumeId, resumePage] });
+          },
+        },
+      );
+    }
+    if (type === 'question') {
+      deleteQuestion(
+        { resumeId, questionId: id, jwt },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['questionList', resumeId, resumePage] });
           },
         },
       );

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -8,7 +8,12 @@ import useDropdown from '@hooks/useDropdown';
 import useEmojiUpdate from '@hooks/useEmojiUpdate';
 import useHover from '@hooks/useHover';
 import { useUserContext } from '@contexts/userContext';
-import { GetCommentList, usePatchEmojiAboutComment, Comment as CommentType } from '@apis/commentApi';
+import {
+  GetCommentList,
+  usePatchEmojiAboutComment,
+  Comment as CommentType,
+  useDeleteComment,
+} from '@apis/commentApi';
 import { Feedback, GetFeedbackList, useDeleteFeedback, usePatchEmojiAboutFeedback } from '@apis/feedbackApi';
 import { GetQuestionList, Question, useDeleteQuestion, usePatchEmojiAboutQuestion } from '@apis/questionApi';
 import { useEmojiList } from '@apis/utilApi';
@@ -203,6 +208,7 @@ const Comment = ({
   // 삭제
   const { mutate: deleteFeedback } = useDeleteFeedback();
   const { mutate: deleteQuestion } = useDeleteQuestion();
+  const { mutate: deleteComment } = useDeleteComment();
 
   const handleDeleteBtnClick = () => {
     if (!jwt) return;
@@ -223,6 +229,16 @@ const Comment = ({
         {
           onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['questionList', resumeId, resumePage] });
+          },
+        },
+      );
+    }
+    if (type === 'comment') {
+      deleteComment(
+        { resumeId, commentId: id, jwt },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['commentList', resumeId] });
           },
         },
       );

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -9,7 +9,7 @@ import useEmojiUpdate from '@hooks/useEmojiUpdate';
 import useHover from '@hooks/useHover';
 import { useUserContext } from '@contexts/userContext';
 import { GetCommentList, usePatchEmojiAboutComment, Comment as CommentType } from '@apis/commentApi';
-import { Feedback, GetFeedbackList, usePatchEmojiAboutFeedback } from '@apis/feedbackApi';
+import { Feedback, GetFeedbackList, useDeleteFeedback, usePatchEmojiAboutFeedback } from '@apis/feedbackApi';
 import { GetQuestionList, Question, usePatchEmojiAboutQuestion } from '@apis/questionApi';
 import { useEmojiList } from '@apis/utilApi';
 import { formatDate } from '@utils';
@@ -200,6 +200,24 @@ const Comment = ({
     }
   };
 
+  // 삭제
+  const { mutate: deleteFeedback } = useDeleteFeedback();
+
+  const handleDeleteBtnClick = () => {
+    if (!jwt) return;
+
+    if (type === 'feedback') {
+      deleteFeedback(
+        { resumeId, feedbackId: id, jwt },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['feedbackList', resumeId, resumePage] });
+          },
+        },
+      );
+    }
+  };
+
   return (
     <>
       <CommentLayout>
@@ -272,6 +290,7 @@ const Comment = ({
                 >
                   <Dropdown.DropdownItem>수정</Dropdown.DropdownItem>
                   <Dropdown.DropdownItem
+                    onClick={handleDeleteBtnClick}
                     $css={css`
                       color: ${theme.palette.red};
                     `}

--- a/src/components/Comment/style.ts
+++ b/src/components/Comment/style.ts
@@ -22,6 +22,14 @@ const Info = styled.div`
   gap: 0.5rem;
 `;
 
+const ButtonsContainer = styled.div`
+  display: flex;
+`;
+
+const MoreIconContainer = styled.div`
+  position: relative;
+`;
+
 const IconButton = styled.button`
   height: 1.5rem;
   background-color: transparent;
@@ -152,6 +160,8 @@ export {
   Top,
   Info,
   IconButton,
+  ButtonsContainer,
+  MoreIconContainer,
   CommentInfo,
   UserImg,
   UserName,

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,0 +1,25 @@
+import type { CSSProp } from 'styled-components';
+import React, { ReactNode } from 'react';
+import { BackDrop, DropdownItem, DropdownLayout } from './style';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  css: CSSProp;
+}
+
+const Dropdown = ({ isOpen, onClose, children, css }: Props) => {
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <BackDrop onClick={onClose} />
+      <DropdownLayout $css={css}>{children}</DropdownLayout>
+    </>
+  );
+};
+
+export default Dropdown;
+
+Dropdown.DropdownItem = DropdownItem;

--- a/src/components/Dropdown/style.ts
+++ b/src/components/Dropdown/style.ts
@@ -1,0 +1,47 @@
+import type { CSSProp } from 'styled-components';
+import { theme } from 'review-me-design-system';
+import styled from 'styled-components';
+
+const DropdownLayout = styled.div<{ $css: CSSProp }>`
+  position: absolute;
+  padding: 0.25rem;
+
+  background-color: ${theme.color.neutral.bg.default};
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
+  border: 1px solid ${theme.color.accent.bd.strong};
+  border-radius: 0.5rem;
+
+  z-index: ${theme.zIndex.modal};
+
+  ${({ $css }) => $css}
+`;
+
+const BackDrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  z-index: ${theme.zIndex.backDrop};
+`;
+
+const DropdownItem = styled.button<{ $css?: CSSProp }>`
+  width: 100%;
+
+  background-color: transparent;
+  border-radius: 8px;
+
+  color: ${theme.color.neutral.text.default};
+  ${theme.font.body.default}
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${theme.palette.green100};
+  }
+
+  ${({ $css }) => $css}
+`;
+
+export { DropdownLayout, BackDrop, DropdownItem };

--- a/src/hooks/useDropdown.ts
+++ b/src/hooks/useDropdown.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+const useDropdown = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = () => {
+    setIsOpen(true);
+  };
+
+  const close = () => {
+    setIsOpen(false);
+  };
+
+  return {
+    isDropdownOpen: isOpen,
+    openDropdown: open,
+    closeDropdown: close,
+  };
+};
+
+export default useDropdown;


### PR DESCRIPTION
## 개요

피드백, 예상질문, 댓글, 대댓글 삭제 API 로직을 구현했다.

## 작업 사항

- 피드백 삭제
  - 대댓글이 있는 피드백을 삭제할 경우, `삭제된 댓글입니다.` 표시하기
- 예상 질문 삭제
  - 대댓글이 있는 예상 질문을 삭제할 경우, `삭제된 댓글입니다.` 표시하기
- 댓글 삭제
- 피드백 대댓글 삭제
- 예상 질문 대댓글 삭제

## 이슈 번호

close #100 
