### PR TITLE
[FE] `올리기` 버튼을 클릭할 경우, 이력서가 업로드 되는 기능 구현

### DIFF
--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -83,12 +83,14 @@ export const postResume = async ({
   scopeId,
   occupationId,
   year,
+  jwt,
 }: {
   title: string;
   pdf: File;
   scopeId: number;
   occupationId: number;
   year: number;
+  jwt: string;
 }) => {
   const formData = new FormData();
   formData.append('title', title);
@@ -99,7 +101,10 @@ export const postResume = async ({
 
   const response = await fetch(REQUEST_URL.RESUME, {
     method: 'POST',
-    cache: 'no-cache',
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      Authorization: `Bearer ${jwt}`,
+    },
     body: formData,
   });
 

--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -102,7 +102,6 @@ export const postResume = async ({
   const response = await fetch(REQUEST_URL.RESUME, {
     method: 'POST',
     headers: {
-      'Content-Type': 'multipart/form-data',
       Authorization: `Bearer ${jwt}`,
     },
     body: formData,

--- a/src/components/ResumeForm/ResumeUploadForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUploadForm/index.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button, Icon, Input, Select } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import PdfViewer from '@components/PdfViewer';
@@ -7,9 +8,11 @@ import usePdf from '@hooks/usePdf';
 import { useUserContext } from '@contexts/userContext';
 import { usePostResume } from '@apis/resumeApi';
 import { Occupation, Scope, useOccupationList, useScopeList } from '@apis/utilApi';
+import { ROUTE_PATH } from '@constants';
 import { Field, FieldContainer, FileLabel, Form, ResumeFormLayout, Label } from '../style';
 
 const ResumeUploadForm = () => {
+  const navigate = useNavigate();
   const PDF_BUTTON_ICON_SIZE = 24;
   const { jwt } = useUserContext();
 
@@ -37,14 +40,22 @@ const ResumeUploadForm = () => {
 
     if (!jwt || !file || !selectedOccupation || !selectedScope || title.length === 0 || !year) return;
 
-    addResume({
-      title,
-      pdf: file,
-      scopeId: selectedScope.id,
-      occupationId: selectedOccupation.id,
-      year,
-      jwt,
-    });
+    addResume(
+      {
+        title,
+        pdf: file,
+        scopeId: selectedScope.id,
+        occupationId: selectedOccupation.id,
+        year,
+        jwt,
+      },
+      {
+        onSuccess: (data) => {
+          const { id } = data;
+          navigate(`${ROUTE_PATH.RESUME}/${id}`);
+        },
+      },
+    );
   };
 
   return (

--- a/src/components/ResumeForm/ResumeUploadForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUploadForm/index.tsx
@@ -1,52 +1,24 @@
-import React, { ChangeEvent, FormEvent } from 'react';
+import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { Button, Icon, Input, Select } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import PdfViewer from '@components/PdfViewer';
 import useMediaQuery from '@hooks/useMediaQuery';
 import usePdf from '@hooks/usePdf';
+import { useUserContext } from '@contexts/userContext';
+import { usePostResume } from '@apis/resumeApi';
 import { Occupation, Scope, useOccupationList, useScopeList } from '@apis/utilApi';
 import { Field, FieldContainer, FileLabel, Form, ResumeFormLayout, Label } from '../style';
 
-interface Props {
-  file?: File;
-  title: string;
-  year?: number;
-  selectedOccupation?: Occupation;
-  selectedScope?: Scope;
-  onChangeFile: (file: File) => void;
-  onChangeTitle: (title: string) => void;
-  onChangeYear: (year: number) => void;
-  onChangeSelectedOccupation: (occupation: Occupation) => void;
-  onChangeSelectedScope: (scope: Scope) => void;
-  onSubmit: ({
-    title,
-    pdf,
-    scopeId,
-    occupationId,
-    year,
-  }: {
-    title: string;
-    pdf: File;
-    scopeId: number;
-    occupationId: number;
-    year: number;
-  }) => void;
-}
-
-const ResumeUploadForm = ({
-  file,
-  title,
-  year,
-  selectedOccupation,
-  selectedScope,
-  onChangeFile,
-  onChangeTitle,
-  onChangeYear,
-  onChangeSelectedOccupation,
-  onChangeSelectedScope,
-  onSubmit,
-}: Props) => {
+const ResumeUploadForm = () => {
   const PDF_BUTTON_ICON_SIZE = 24;
+  const { jwt } = useUserContext();
+
+  const [file, setFile] = useState<File | undefined>();
+  const [title, setTitle] = useState<string>('');
+  const [selectedOccupation, setSelectedOccupation] = useState<Occupation | undefined>();
+  const [selectedScope, setSelectedScope] = useState<Scope | undefined>();
+  const [year, setYear] = useState<number | undefined>();
+  const { mutate: addResume } = usePostResume();
 
   const { totalPages, scale, zoomIn, zoomOut, setTotalPages } = usePdf({});
   const { matches: isMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 768px)' });
@@ -57,19 +29,21 @@ const ResumeUploadForm = ({
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
 
-    if (files && files[0]) onChangeFile(files[0]);
+    if (files && files[0]) setFile(files[0]);
   };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!file || !selectedOccupation || !selectedScope || title.length === 0 || !year) return;
 
-    onSubmit({
+    if (!jwt || !file || !selectedOccupation || !selectedScope || title.length === 0 || !year) return;
+
+    addResume({
       title,
       pdf: file,
       scopeId: selectedScope.id,
       occupationId: selectedOccupation.id,
       year,
+      jwt,
     });
   };
 
@@ -126,7 +100,7 @@ const ResumeUploadForm = ({
 
           <Field>
             <Label htmlFor="title">제목</Label>
-            <Input id="title" name="title" onChange={(e) => onChangeTitle(e.target.value)} />
+            <Input id="title" name="title" onChange={(e) => setTitle(e.target.value)} />
           </Field>
 
           <Field>
@@ -135,7 +109,7 @@ const ResumeUploadForm = ({
               width="100%"
               onSelectOption={(option) => {
                 if (option && typeof option.name === 'string' && typeof option.value === 'number')
-                  onChangeSelectedScope({ id: option.value, scope: option.name });
+                  setSelectedScope({ id: option.value, scope: option.name });
               }}
             >
               <Select.TriggerButton height="2.875rem" />
@@ -157,7 +131,7 @@ const ResumeUploadForm = ({
               width="100%"
               onSelectOption={(option) => {
                 if (option && typeof option.name === 'string' && typeof option.value === 'number')
-                  onChangeSelectedOccupation({ id: option.value, occupation: option.name });
+                  setSelectedOccupation({ id: option.value, occupation: option.name });
               }}
             >
               <Select.TriggerButton height="2.875rem" />
@@ -181,7 +155,7 @@ const ResumeUploadForm = ({
               name="year"
               placeholder="신입일 경우 0 입력"
               min={0}
-              onChange={(e) => onChangeYear(e.target.valueAsNumber)}
+              onChange={(e) => setYear(e.target.valueAsNumber)}
             />
           </Field>
         </FieldContainer>

--- a/src/pages/ResumeUpload/index.tsx
+++ b/src/pages/ResumeUpload/index.tsx
@@ -1,21 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Icon } from 'review-me-design-system';
 import ResumeUploadForm from '@components/ResumeForm/ResumeUploadForm';
-import { usePostResume } from '@apis/resumeApi';
-import { Occupation, Scope } from '@apis/utilApi';
 import { PageMain } from '@styles/common';
 import { ResumeUploadContainer, IconButton, Description, MainDescription, SubDescription } from './style';
 
 const ResumeUpload = () => {
   const navigate = useNavigate();
-
-  const [file, setFile] = useState<File | undefined>();
-  const [title, setTitle] = useState<string>('');
-  const [selectedOccupation, setSelectedOccupation] = useState<Occupation | undefined>();
-  const [selectedScope, setSelectedScope] = useState<Scope | undefined>();
-  const [year, setYear] = useState<number | undefined>();
-  const { mutate: addResume } = usePostResume();
 
   return (
     <PageMain>
@@ -30,19 +21,7 @@ const ResumeUpload = () => {
           <SubDescription>제출된 이력서 pdf 파일은 변경이 불가합니다.</SubDescription>
         </Description>
 
-        <ResumeUploadForm
-          file={file}
-          title={title}
-          year={year}
-          selectedOccupation={selectedOccupation}
-          selectedScope={selectedScope}
-          onChangeFile={setFile}
-          onChangeTitle={setTitle}
-          onChangeYear={setYear}
-          onChangeSelectedOccupation={setSelectedOccupation}
-          onChangeSelectedScope={setSelectedScope}
-          onSubmit={addResume}
-        />
+        <ResumeUploadForm />
       </ResumeUploadContainer>
     </PageMain>
   );


### PR DESCRIPTION
## 개요

이력서 추가 요청보내는 API 로직을 수정했다.

## 작업 사항

- 이력서 추가 요청 보내는 함수와 custom hook의 매개변수에 jwt 추가
- request header에 Content-Type 빼기
  - 이유: 브라우저가 알아서 Content-Type과 boundary를 설정해주기 때문 ([참고](https://stackoverflow.com/questions/39280438/fetch-missing-boundary-in-multipart-form-data-post)) 
- 요청이 성공적이라면, 업로드한 이력서의 상세 페이지로 이동

## 이슈 번호

close #95 