### PR TITLE
[FE] 피드백과 예상질문의 check 기능 구현

### DIFF
--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -21,7 +21,13 @@ import {
   usePatchEmojiAboutFeedback,
   usePatchFeedbackCheck,
 } from '@apis/feedbackApi';
-import { GetQuestionList, Question, useDeleteQuestion, usePatchEmojiAboutQuestion } from '@apis/questionApi';
+import {
+  GetQuestionList,
+  Question,
+  useDeleteQuestion,
+  usePatchEmojiAboutQuestion,
+  usePatchQuestionCheck,
+} from '@apis/questionApi';
 import { useEmojiList } from '@apis/utilApi';
 import { formatDate } from '@utils';
 import {
@@ -253,6 +259,7 @@ const Comment = ({
 
   // Check 수정
   const { mutate: toggleCheckAboutFeedback } = usePatchFeedbackCheck({ resumePage });
+  const { mutate: toggleCheckAboutQuestion } = usePatchQuestionCheck({ resumePage });
 
   const handleCheckMarkClick = () => {
     if (!jwt) return;
@@ -261,6 +268,14 @@ const Comment = ({
       toggleCheckAboutFeedback({
         resumeId,
         feedbackId: id,
+        checked: !checked,
+        jwt,
+      });
+    }
+    if (type === 'question') {
+      toggleCheckAboutQuestion({
+        resumeId,
+        questionId: id,
         checked: !checked,
         jwt,
       });

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -14,7 +14,13 @@ import {
   Comment as CommentType,
   useDeleteComment,
 } from '@apis/commentApi';
-import { Feedback, GetFeedbackList, useDeleteFeedback, usePatchEmojiAboutFeedback } from '@apis/feedbackApi';
+import {
+  Feedback,
+  GetFeedbackList,
+  useDeleteFeedback,
+  usePatchEmojiAboutFeedback,
+  usePatchFeedbackCheck,
+} from '@apis/feedbackApi';
 import { GetQuestionList, Question, useDeleteQuestion, usePatchEmojiAboutQuestion } from '@apis/questionApi';
 import { useEmojiList } from '@apis/utilApi';
 import { formatDate } from '@utils';
@@ -245,6 +251,22 @@ const Comment = ({
     }
   };
 
+  // Check 수정
+  const { mutate: toggleCheckAboutFeedback } = usePatchFeedbackCheck({ resumePage });
+
+  const handleCheckMarkClick = () => {
+    if (!jwt) return;
+
+    if (type === 'feedback') {
+      toggleCheckAboutFeedback({
+        resumeId,
+        feedbackId: id,
+        checked: !checked,
+        jwt,
+      });
+    }
+  };
+
   return (
     <>
       <CommentLayout>
@@ -278,7 +300,7 @@ const Comment = ({
               </IconButton>
             )}
             {hasCheckMarkIcon && (
-              <IconButton>
+              <IconButton onClick={handleCheckMarkClick}>
                 {checked ? (
                   <Icon
                     iconName="filledCheckMark"


### PR DESCRIPTION
## 개요

피드백과 예상질문에 있는 check 표시를 클릭하면, 클릭한 데이터의 check 수정 요청을 서버에 보낸다.

## 작업 사항

- 피드백 check 수정 보내는 함수와 custom hook 구현
  - optimistic update 적용
- 예상질문 check 수정 보내는 함수와 custom hook 구현
  - optimistic update 적용

## 이슈 번호

close #99 