### PR TITLE
[FE] 직군, 경력 필터에 따라 원하는 이력서만 볼 수 있는 기능

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "react-dom": "^18.2.0",
         "react-pdf": "^7.7.0",
         "react-router-dom": "^6.19.0",
-        "review-me-design-system": "^0.0.11",
+        "review-me-design-system": "^0.0.12",
         "styled-components": "^6.1.1"
       },
       "devDependencies": {
@@ -17935,9 +17935,9 @@
       }
     },
     "node_modules/review-me-design-system": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/review-me-design-system/-/review-me-design-system-0.0.11.tgz",
-      "integrity": "sha512-FPJ+Fed+I2f+KFmf6PgILfrw9Iol/5J09MT/MCRQKWxn7uVSyqrlD1T9xnilu6d4qeb7OJrJjgSoqVEYneT2aA==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/review-me-design-system/-/review-me-design-system-0.0.12.tgz",
+      "integrity": "sha512-dilxBisN8krXLrSssV7S/FTLGvQbIdsN3TUb4oceJNcCG9+6XTfO9kfuE28il9z+gvUwpwIv9+S5rEF3bCxCOQ==",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react-dom": "^18.2.0",
     "react-pdf": "^7.7.0",
     "react-router-dom": "^6.19.0",
-    "review-me-design-system": "^0.0.11",
+    "review-me-design-system": "^0.0.12",
     "styled-components": "^6.1.1"
   },
   "devDependencies": {

--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -21,7 +21,15 @@ interface GetResumeList extends PageNationData {
   resumes: ResumeList;
 }
 
-export const getResumeList = async ({ pageParam, jwt }: { pageParam: number; jwt?: string }) => {
+export const getResumeList = async ({
+  pageParam,
+  jwt,
+  occupationId,
+}: {
+  pageParam: number;
+  jwt?: string;
+  occupationId?: number;
+}) => {
   const headers = new Headers();
   if (jwt) headers.append('Authorization', `Bearer ${jwt}`);
 
@@ -29,7 +37,10 @@ export const getResumeList = async ({ pageParam, jwt }: { pageParam: number; jwt
     headers,
   };
 
-  const response = await fetch(`${REQUEST_URL.RESUME}?page=${pageParam}`, requestOptions);
+  let queryString = `page=${pageParam}`;
+  if (occupationId) queryString += `&occupationId=${occupationId}`;
+
+  const response = await fetch(`${REQUEST_URL.RESUME}?${queryString}`, requestOptions);
 
   if (!response.ok) {
     throw response;
@@ -42,13 +53,14 @@ export const getResumeList = async ({ pageParam, jwt }: { pageParam: number; jwt
 
 interface UseResumeListProps {
   jwt?: string;
+  occupationId?: number;
 }
 
-export const useResumeList = ({ jwt }: UseResumeListProps) => {
+export const useResumeList = ({ jwt, occupationId }: UseResumeListProps) => {
   return useInfiniteQuery({
-    queryKey: ['resumeList'],
+    queryKey: ['resumeList', occupationId],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getResumeList({ pageParam, jwt }),
+    queryFn: ({ pageParam }) => getResumeList({ pageParam, jwt, occupationId }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -25,10 +25,14 @@ export const getResumeList = async ({
   pageParam,
   jwt,
   occupationId,
+  startYear,
+  endYear,
 }: {
   pageParam: number;
   jwt?: string;
   occupationId?: number;
+  startYear: number;
+  endYear: number;
 }) => {
   const headers = new Headers();
   if (jwt) headers.append('Authorization', `Bearer ${jwt}`);
@@ -39,6 +43,8 @@ export const getResumeList = async ({
 
   let queryString = `page=${pageParam}`;
   if (occupationId) queryString += `&occupationId=${occupationId}`;
+  queryString += `&startYear=${startYear}`;
+  if (endYear < 10) queryString += `&endYear=${endYear}`;
 
   const response = await fetch(`${REQUEST_URL.RESUME}?${queryString}`, requestOptions);
 
@@ -54,13 +60,17 @@ export const getResumeList = async ({
 interface UseResumeListProps {
   jwt?: string;
   occupationId?: number;
+  startYear: number;
+  endYear: number;
 }
 
-export const useResumeList = ({ jwt, occupationId }: UseResumeListProps) => {
+export const useResumeList = ({ jwt, occupationId, startYear, endYear }: UseResumeListProps) => {
+  const yearFilter = { startYear, endYear };
+
   return useInfiniteQuery({
-    queryKey: ['resumeList', occupationId],
+    queryKey: ['resumeList', occupationId, yearFilter],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getResumeList({ pageParam, jwt, occupationId }),
+    queryFn: ({ pageParam }) => getResumeList({ pageParam, jwt, occupationId, startYear, endYear }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -21,8 +21,15 @@ interface GetResumeList extends PageNationData {
   resumes: ResumeList;
 }
 
-export const getResumeList = async (pageParam: number) => {
-  const response = await fetch(`${REQUEST_URL.RESUME}?page=${pageParam}`);
+export const getResumeList = async ({ pageParam, jwt }: { pageParam: number; jwt?: string }) => {
+  const headers = new Headers();
+  if (jwt) headers.append('Authorization', `Bearer ${jwt}`);
+
+  const requestOptions: RequestInit = {
+    headers,
+  };
+
+  const response = await fetch(`${REQUEST_URL.RESUME}?page=${pageParam}`, requestOptions);
 
   if (!response.ok) {
     throw response;
@@ -33,11 +40,15 @@ export const getResumeList = async (pageParam: number) => {
   return data;
 };
 
-export const useResumeList = () => {
+interface UseResumeListProps {
+  jwt?: string;
+}
+
+export const useResumeList = ({ jwt }: UseResumeListProps) => {
   return useInfiniteQuery({
     queryKey: ['resumeList'],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getResumeList(pageParam),
+    queryFn: ({ pageParam }) => getResumeList({ pageParam, jwt }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/components/Select/style.ts
+++ b/src/components/Select/style.ts
@@ -15,6 +15,11 @@ const SelectLayout = styled.select<{ $width: string }>`
 
   ${({ theme }) => theme.font.body.default}
   color: ${({ theme }) => theme.color.neutral.text.default};
+
+  &:focus {
+    outline: none;
+    border-color: ${theme.color.accent.bd.strong};
+  }
 `;
 
 export { SelectLayout };

--- a/src/components/YearRangeFilter/index.tsx
+++ b/src/components/YearRangeFilter/index.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { Button, MultiRangeSlider } from 'review-me-design-system';
+import { getRangeText } from '@utils';
+import { ButtonsContainer, YearRangeFilterLayout } from './style';
+
+interface Range {
+  min: number;
+  max: number;
+}
+
+interface Props {
+  min: number;
+  max: number;
+  startYear: number;
+  endYear: number;
+  onCancelRangeChange: () => void;
+  onApplyRangeChange: (range: Range) => void;
+}
+
+const YearRangeFilter = ({
+  min,
+  max,
+  startYear,
+  endYear,
+  onCancelRangeChange,
+  onApplyRangeChange,
+}: Props) => {
+  const [range, setRange] = useState<Range>({ min: startYear, max: endYear });
+  const rangeText = getRangeText({ min: range.min, max: range.max });
+
+  return (
+    <YearRangeFilterLayout>
+      <span>{rangeText}</span>
+      <MultiRangeSlider
+        hasGreaterCheck={true}
+        min={min}
+        max={max}
+        range={range}
+        onRangeChange={setRange}
+        width="17.5rem"
+      />
+      <ButtonsContainer>
+        <Button variant="outline" size="s" onClick={onCancelRangeChange}>
+          취소
+        </Button>
+        <Button
+          variant="default"
+          size="s"
+          onClick={() => {
+            onApplyRangeChange(range);
+          }}
+        >
+          적용
+        </Button>
+      </ButtonsContainer>
+    </YearRangeFilterLayout>
+  );
+};
+
+export default YearRangeFilter;

--- a/src/components/YearRangeFilter/index.tsx
+++ b/src/components/YearRangeFilter/index.tsx
@@ -31,14 +31,7 @@ const YearRangeFilter = ({
   return (
     <YearRangeFilterLayout>
       <span>{rangeText}</span>
-      <MultiRangeSlider
-        hasGreaterCheck={true}
-        min={min}
-        max={max}
-        range={range}
-        onRangeChange={setRange}
-        width="17.5rem"
-      />
+      <MultiRangeSlider hasGreaterCheck={true} min={min} max={max} range={range} onRangeChange={setRange} />
       <ButtonsContainer>
         <Button variant="outline" size="s" onClick={onCancelRangeChange}>
           취소

--- a/src/components/YearRangeFilter/style.ts
+++ b/src/components/YearRangeFilter/style.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const YearRangeFilterLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+  width: 100%;
+  height: fit-content;
+  padding: 0.75rem;
+`;
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+`;
+
+export { YearRangeFilterLayout, ButtonsContainer };

--- a/src/pages/Resume/index.tsx
+++ b/src/pages/Resume/index.tsx
@@ -11,13 +11,14 @@ import { ROUTE_PATH } from '@constants';
 import { Filter, FilterContainer, Main, MainHeader, ResumeList } from './style';
 
 const Resume = () => {
-  const { isLoggedIn, jwt } = useUserContext();
   const navigate = useNavigate();
+
+  const { isLoggedIn, jwt } = useUserContext();
 
   const [occupationId, setOccupationId] = useState<number | undefined>();
 
   const { data: occupationList } = useOccupationList();
-  const { data: resumeListData, fetchNextPage } = useResumeList({ jwt });
+  const { data: resumeListData, fetchNextPage } = useResumeList({ jwt, occupationId });
 
   const { setTarget } = useIntersectionObserver({
     onIntersect: () => fetchNextPage(),
@@ -45,6 +46,7 @@ const Resume = () => {
 
                 setOccupationId(Number(e.target.value));
               }}
+              width="10.25rem"
             >
               <option value="all">전체</option>
               {occupationList?.map(({ id, occupation }) => {

--- a/src/pages/Resume/index.tsx
+++ b/src/pages/Resume/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from 'review-me-design-system';
 import ResumeItem from '@components/ResumeItem';
@@ -12,6 +12,7 @@ import { Filter, FilterContainer, Main, MainHeader, ResumeList } from './style';
 
 const Resume = () => {
   const navigate = useNavigate();
+  const occupationFilterRef = useRef<HTMLSelectElement>(null);
 
   const { isLoggedIn, jwt } = useUserContext();
 
@@ -34,8 +35,15 @@ const Resume = () => {
       <MainHeader>
         <FilterContainer>
           <Filter>
-            <span>직군</span>
+            <span
+              onClick={() => {
+                occupationFilterRef.current?.focus();
+              }}
+            >
+              직군
+            </span>
             <Select
+              ref={occupationFilterRef}
               value={occupationId}
               defaultValue={'all'}
               onChange={(e) => {

--- a/src/pages/Resume/index.tsx
+++ b/src/pages/Resume/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button } from 'review-me-design-system';
+import { Button, Modal, useModal } from 'review-me-design-system';
 import { css } from 'styled-components';
 import Dropdown from '@components/Dropdown';
 import ResumeItem from '@components/ResumeItem';
@@ -8,6 +8,7 @@ import Select from '@components/Select';
 import YearRangeFilter from '@components/YearRangeFilter';
 import useDropdown from '@hooks/useDropdown';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
+import useMediaQuery from '@hooks/useMediaQuery';
 import { useUserContext } from '@contexts/userContext';
 import { useResumeList } from '@apis/resumeApi';
 import { useOccupationList } from '@apis/utilApi';
@@ -27,9 +28,12 @@ const Resume = () => {
     endYear: 10,
   });
 
+  const { matches: isMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 768px)' });
+
   const rangeText = getRangeText({ min: yearRange.startYear, max: yearRange.endYear });
 
   const { isDropdownOpen, openDropdown, closeDropdown } = useDropdown();
+  const { isOpen: isModalOpen, open: openModal, close: closeModal } = useModal();
 
   const { data: occupationList } = useOccupationList();
   const { data: resumeListData, fetchNextPage } = useResumeList({
@@ -51,7 +55,7 @@ const Resume = () => {
   return (
     <Main>
       <MainHeader>
-        <FilterContainer>
+        <FilterContainer $isMDevice={isMDevice}>
           <Filter>
             <span
               onClick={() => {
@@ -101,6 +105,7 @@ const Resume = () => {
               isOpen={isDropdownOpen}
               onClose={closeDropdown}
               css={css`
+                width: ${isMDevice ? '16rem' : '17.5rem'};
                 top: 2.875rem;
                 left: 0;
               `}

--- a/src/pages/Resume/index.tsx
+++ b/src/pages/Resume/index.tsx
@@ -11,13 +11,13 @@ import { ROUTE_PATH } from '@constants';
 import { Filter, FilterContainer, Main, MainHeader, ResumeList } from './style';
 
 const Resume = () => {
-  const { isLoggedIn } = useUserContext();
+  const { isLoggedIn, jwt } = useUserContext();
   const navigate = useNavigate();
 
   const [occupationId, setOccupationId] = useState<number | undefined>();
 
   const { data: occupationList } = useOccupationList();
-  const { data: resumeListData, fetchNextPage } = useResumeList();
+  const { data: resumeListData, fetchNextPage } = useResumeList({ jwt });
 
   const { setTarget } = useIntersectionObserver({
     onIntersect: () => fetchNextPage(),

--- a/src/pages/Resume/style.ts
+++ b/src/pages/Resume/style.ts
@@ -38,12 +38,27 @@ const FilterContainer = styled.div`
 `;
 
 const Filter = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
   gap: 0.5rem;
 
   ${theme.font.body.default}
   color: ${theme.color.neutral.text.default};
+`;
+
+const YearRange = styled.button`
+  display: flex;
+  position: relative;
+  width: 10.25rem;
+  padding: 0.5rem 0.75rem;
+
+  background-color: ${theme.color.neutral.bg.default};
+  border-radius: 0.25rem;
+  border: 0.0625rem solid ${theme.color.accent.bd.weak};
+
+  ${({ theme }) => theme.font.body.default}
+  color: ${({ theme }) => theme.color.neutral.text.default};
 `;
 
 const ResumeList = styled.ul`
@@ -62,4 +77,4 @@ const ResumeList = styled.ul`
   }
 `;
 
-export { Main, MainHeader, FilterContainer, Filter, ResumeList };
+export { Main, MainHeader, FilterContainer, Filter, YearRange, ResumeList };

--- a/src/pages/Resume/style.ts
+++ b/src/pages/Resume/style.ts
@@ -31,8 +31,9 @@ const MainHeader = styled.header`
   }
 `;
 
-const FilterContainer = styled.div`
+const FilterContainer = styled.div<{ $isMDevice: boolean }>`
   display: flex;
+  flex-direction: ${({ $isMDevice }) => ($isMDevice ? 'column' : 'row')};
   align-items: center;
   gap: 0.75rem;
 `;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,3 +30,18 @@ export const parseJwt = (token: string) => {
 
   return JSON.parse(jsonPayload);
 };
+
+export const getRangeText = ({ min, max }: { min: number; max: number }) => {
+  if (min === max) {
+    if (min === 0) return '신입';
+    if (min === 10) return '10년 +';
+    return `${min}년`;
+  }
+
+  if (min === 0 && max === 10) return '전체';
+
+  const minText = min === 0 ? '신입' : `${min}년`;
+  const maxText = max === 10 ? '10년 +' : `${max}년`;
+
+  return `${minText} ~ ${maxText}`;
+};


### PR DESCRIPTION
## 개요

이력서 메인 페이지에서 직군, 경력 필터 설정에 따라 해당되는 이력서 목록을 보여준다.

## 작업 사항

- 원하는 직군을 클릭하면, 선택한 직군에 해당하는 이력서만 볼 수 있다.
- 원하는 경력 필터를 선택하면, 선택한 경력에 해당하는 이력서만 볼 수 있다.
- 디바이스 가로 길이가 768px 이하인 경우, 필터 레이아웃 설정

## 이슈 번호

close #110 
