### PR TITLE
[FE] 이력서 수정 페이지에서 수정하기 버튼을 클릭할 경우, 수정 내용이 반영된 해당 이력서의 상세 페이지로 이동 

### DIFF
--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -245,16 +245,22 @@ export const updateResume = async ({
   scopeId,
   occupationId,
   year,
+  jwt,
 }: {
   resumeId: number;
   title: string;
   scopeId: number;
   occupationId: number;
   year: number;
+  jwt: string;
 }) => {
   const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}`, {
     method: 'PATCH',
     body: JSON.stringify({ title, scopeId, occupationId, year }),
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
   });
 
   if (!response.ok) {

--- a/src/components/ResumeForm/ResumeUpdateForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUpdateForm/index.tsx
@@ -1,12 +1,15 @@
 import React, { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button, Icon, Input } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import PdfViewer from '@components/PdfViewer';
 import Select from '@components/Select';
 import useMediaQuery from '@hooks/useMediaQuery';
 import usePdf from '@hooks/usePdf';
+import { useUserContext } from '@contexts/userContext';
 import { useUpdateResume } from '@apis/resumeApi';
 import { useOccupationList, useScopeList } from '@apis/utilApi';
+import { ROUTE_PATH } from '@constants';
 import { Field, FieldContainer, Form, ResumeFormLayout, Label } from '../style';
 
 interface Props {
@@ -19,8 +22,12 @@ interface Props {
 }
 
 const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupation, initScope, initYear }: Props) => {
+  const navigate = useNavigate();
+
   const { data: occupationList } = useOccupationList();
   const { data: scopeList } = useScopeList();
+
+  const { jwt } = useUserContext();
 
   const initOccupationId = occupationList?.find(({ occupation }) => occupation === initOccupation)?.id;
   const initScopeId = scopeList?.find(({ scope }) => scope === initScope)?.id;
@@ -39,15 +46,23 @@ const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupation, initScope
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!occupationId || !scopeId || title.length === 0 || !year) return;
+    if (!jwt || !occupationId || !scopeId || title.length === 0 || !year) return;
 
-    updateResume({
-      resumeId,
-      title,
-      scopeId,
-      occupationId,
-      year,
-    });
+    updateResume(
+      {
+        resumeId,
+        title,
+        scopeId,
+        occupationId,
+        year,
+        jwt,
+      },
+      {
+        onSuccess: () => {
+          navigate(`${ROUTE_PATH.RESUME}/${resumeId}`);
+        },
+      },
+    );
   };
 
   return (

--- a/src/pages/ResumeUpdate/index.tsx
+++ b/src/pages/ResumeUpdate/index.tsx
@@ -5,7 +5,7 @@ import ResumeUpdateForm from '@components/ResumeForm/ResumeUpdateForm';
 import { useUserContext } from '@contexts/userContext';
 import { useResumeDetail } from '@apis/resumeApi';
 import { PageMain } from '@styles/common';
-import { ResumeUploadContainer, IconButton, Description, MainDescription } from './style';
+import { ResumeUploadContainer, IconButton, Description, MainDescription, SubDescription } from './style';
 
 interface Location {
   state: { resumeId: number; title: string; year: number; occupation: string; scope: string };
@@ -33,6 +33,7 @@ const ResumeUpdate = () => {
       <ResumeUploadContainer>
         <Description>
           <MainDescription>이력서 수정</MainDescription>
+          <SubDescription>아래의 양식을 작성하고 수정하기 버튼을 눌러주세요.</SubDescription>
         </Description>
 
         <ResumeUpdateForm

--- a/src/pages/ResumeUpdate/style.ts
+++ b/src/pages/ResumeUpdate/style.ts
@@ -37,4 +37,9 @@ const MainDescription = styled.span`
   color: ${theme.color.neutral.text.strong};
 `;
 
-export { IconButton, ResumeUploadContainer, Description, MainDescription };
+const SubDescription = styled.span`
+  ${theme.font.body.default}
+  color: ${theme.color.neutral.text.strong}
+`;
+
+export { IconButton, ResumeUploadContainer, Description, MainDescription, SubDescription };


### PR DESCRIPTION
## 개요

이력서를 수정하는 기능을 구현했다.

## 작업 사항

- 이력서 수정 요청을 보내는 함수와 custom hook의 매개변수에 jwt를 추가
- 이력서 수정 페이지에 안내 문구 추가
- 수정하기 버튼을 클릭할 경우
  - 서버에 이력서 수정 요청
  - 변경된 내용이 반영된 이력서 상세페이지로 이동

## 이슈 번호

close #119 