### PR TITLE
[FE] 예상질문 수정 기능

### DIFF
--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -234,6 +234,46 @@ export const useDeleteQuestion = () => {
   return useMutation({ mutationFn: deleteQuestion });
 };
 
+// PATCH 예상질문 수정
+export const patchQuestion = async ({
+  resumeId,
+  questionId,
+  labelContent,
+  content,
+  jwt,
+}: {
+  resumeId: number;
+  questionId: number;
+  labelContent: string | null;
+  content: string | null;
+  jwt: string;
+}) => {
+  const requestBody: { labelContent?: string; content?: string } = {};
+  if (labelContent) requestBody.labelContent = labelContent;
+  if (content) requestBody.content = content;
+
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/question/${questionId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const usePatchQuestion = () => {
+  return useMutation({ mutationFn: patchQuestion });
+};
+
 // PATCH 예상질문 체크 상태 수정
 export const patchQuestionCheck = async ({
   resumeId,

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -3,6 +3,7 @@ import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { Icon, Label as EmojiLabel, theme } from 'review-me-design-system';
 import { css } from 'styled-components';
 import Dropdown from '@components/Dropdown';
+import QuestionEditForm from '@components/QuestionForm/QuestionEditForm';
 import ReplyList from '@components/ReplyList';
 import useDropdown from '@hooks/useDropdown';
 import useEmojiUpdate from '@hooks/useEmojiUpdate';
@@ -99,6 +100,7 @@ const Comment = ({
   const { isHover, changeHoverState } = useHover();
   const { isDropdownOpen, openDropdown, closeDropdown } = useDropdown();
   const [isOpenReplyList, setIsOpenReplyList] = useState<boolean>(false);
+  const [isEdited, setIsEdited] = useState<boolean>(false);
 
   const ICON_SIZE = 24;
   const REPLY_ICON_SIZE = 20;
@@ -258,6 +260,12 @@ const Comment = ({
     }
   };
 
+  // 수정
+  const handleEditBtnClick = () => {
+    setIsEdited(true);
+    closeDropdown();
+  };
+
   // Check 수정
   const { mutate: toggleCheckAboutFeedback } = usePatchFeedbackCheck({ resumePage });
   const { mutate: toggleCheckAboutQuestion } = usePatchQuestionCheck({ resumePage });
@@ -309,142 +317,158 @@ const Comment = ({
             </CommentInfo>
           </Info>
 
-          <ButtonsContainer>
-            {hasBookMarkIcon && (
-              <IconButton onClick={handleBookMarkClick}>
-                {bookmarked ? (
-                  <Icon
-                    iconName="filledBookMark"
-                    width={ICON_SIZE}
-                    height={ICON_SIZE}
-                    color={theme.color.accent.bg.default}
-                  />
-                ) : (
-                  <Icon
-                    iconName="bookMark"
-                    width={ICON_SIZE}
-                    height={ICON_SIZE}
-                    color={theme.color.accent.bg.strong}
-                  />
-                )}
-              </IconButton>
-            )}
-            {hasCheckMarkIcon && (
-              <IconButton onClick={handleCheckMarkClick}>
-                {checked ? (
-                  <Icon
-                    iconName="filledCheckMark"
-                    width={ICON_SIZE}
-                    height={ICON_SIZE}
-                    color={theme.color.accent.bg.default}
-                  />
-                ) : (
-                  <Icon
-                    iconName="checkMark"
-                    width={ICON_SIZE}
-                    height={ICON_SIZE}
-                    color={theme.color.accent.bg.strong}
-                  />
-                )}
-              </IconButton>
-            )}
-            {hasMoreIcon && (
-              <MoreIconContainer>
-                <IconButton onClick={openDropdown}>
-                  <Icon
-                    iconName="more"
-                    width={ICON_SIZE}
-                    height={ICON_SIZE}
-                    color={theme.color.accent.bg.strong}
-                  />
+          {!isEdited && (
+            <ButtonsContainer>
+              {hasBookMarkIcon && (
+                <IconButton onClick={handleBookMarkClick}>
+                  {bookmarked ? (
+                    <Icon
+                      iconName="filledBookMark"
+                      width={ICON_SIZE}
+                      height={ICON_SIZE}
+                      color={theme.color.accent.bg.default}
+                    />
+                  ) : (
+                    <Icon
+                      iconName="bookMark"
+                      width={ICON_SIZE}
+                      height={ICON_SIZE}
+                      color={theme.color.accent.bg.strong}
+                    />
+                  )}
                 </IconButton>
-                <Dropdown
-                  isOpen={isDropdownOpen}
-                  onClose={closeDropdown}
-                  css={css`
-                    width: 4rem;
-                    top: 1.5rem;
-                    right: 0;
-                  `}
-                >
-                  <Dropdown.DropdownItem>수정</Dropdown.DropdownItem>
-                  <Dropdown.DropdownItem
-                    onClick={handleDeleteBtnClick}
-                    $css={css`
-                      color: ${theme.palette.red};
+              )}
+              {hasCheckMarkIcon && (
+                <IconButton onClick={handleCheckMarkClick}>
+                  {checked ? (
+                    <Icon
+                      iconName="filledCheckMark"
+                      width={ICON_SIZE}
+                      height={ICON_SIZE}
+                      color={theme.color.accent.bg.default}
+                    />
+                  ) : (
+                    <Icon
+                      iconName="checkMark"
+                      width={ICON_SIZE}
+                      height={ICON_SIZE}
+                      color={theme.color.accent.bg.strong}
+                    />
+                  )}
+                </IconButton>
+              )}
+              {hasMoreIcon && (
+                <MoreIconContainer>
+                  <IconButton onClick={openDropdown}>
+                    <Icon
+                      iconName="more"
+                      width={ICON_SIZE}
+                      height={ICON_SIZE}
+                      color={theme.color.accent.bg.strong}
+                    />
+                  </IconButton>
+                  <Dropdown
+                    isOpen={isDropdownOpen}
+                    onClose={closeDropdown}
+                    css={css`
+                      width: 4rem;
+                      top: 1.5rem;
+                      right: 0;
                     `}
                   >
-                    삭제
-                  </Dropdown.DropdownItem>
-                </Dropdown>
-              </MoreIconContainer>
-            )}
-          </ButtonsContainer>
+                    <Dropdown.DropdownItem onClick={handleEditBtnClick}>수정</Dropdown.DropdownItem>
+                    <Dropdown.DropdownItem
+                      onClick={handleDeleteBtnClick}
+                      $css={css`
+                        color: ${theme.palette.red};
+                      `}
+                    >
+                      삭제
+                    </Dropdown.DropdownItem>
+                  </Dropdown>
+                </MoreIconContainer>
+              )}
+            </ButtonsContainer>
+          )}
         </Top>
 
-        <CommentContent>
-          {labelContent && <SelectedLabel>{labelContent}</SelectedLabel>}
-          <Content>{content ?? '삭제된 댓글입니다.'}</Content>
-        </CommentContent>
+        {isEdited && type === 'question' && (
+          <QuestionEditForm
+            resumeId={resumeId}
+            currentPageNum={resumePage}
+            questionId={id}
+            initLabelContent={labelContent}
+            initContent={content}
+            onCancelEdit={() => setIsEdited(false)}
+          />
+        )}
+        {!isEdited && (
+          <>
+            <CommentContent>
+              {labelContent && <SelectedLabel>{labelContent}</SelectedLabel>}
+              <Content>{content ?? '삭제된 댓글입니다.'}</Content>
+            </CommentContent>
 
-        <Bottom>
-          {hasReplyIcon && (
-            <OpenReplyButton onClick={handleReplyButtonClick}>
-              <Icon iconName="communication" width={REPLY_ICON_SIZE} height={REPLY_ICON_SIZE} />
-              <span>{countOfReplies}</span>
-            </OpenReplyButton>
-          )}
-          <EmojiButtonContainer>
-            <EmojiButton
-              onMouseEnter={() => changeHoverState(true)}
-              onMouseLeave={() => changeHoverState(false)}
-            >
-              <Icon iconName="emoji" />
-            </EmojiButton>
-            <EmojiModal
-              className={isHover ? 'active' : ''}
-              onMouseEnter={() => changeHoverState(true)}
-              onMouseLeave={() => changeHoverState(false)}
-            >
-              {emojiList?.map(({ id, emoji }) => {
-                return (
-                  <EmojiLabel
-                    key={id}
-                    isActive={id === myEmojiId}
-                    py="0.5rem"
-                    px="0.75rem"
-                    onClick={(e) => handleEmojiLabelClick(e, id)}
-                  >
-                    {emoji}
-                  </EmojiLabel>
-                );
-              })}
-            </EmojiModal>
-          </EmojiButtonContainer>
+            <Bottom>
+              {hasReplyIcon && (
+                <OpenReplyButton onClick={handleReplyButtonClick}>
+                  <Icon iconName="communication" width={REPLY_ICON_SIZE} height={REPLY_ICON_SIZE} />
+                  <span>{countOfReplies}</span>
+                </OpenReplyButton>
+              )}
+              <EmojiButtonContainer>
+                <EmojiButton
+                  onMouseEnter={() => changeHoverState(true)}
+                  onMouseLeave={() => changeHoverState(false)}
+                >
+                  <Icon iconName="emoji" />
+                </EmojiButton>
+                <EmojiModal
+                  className={isHover ? 'active' : ''}
+                  onMouseEnter={() => changeHoverState(true)}
+                  onMouseLeave={() => changeHoverState(false)}
+                >
+                  {emojiList?.map(({ id, emoji }) => {
+                    return (
+                      <EmojiLabel
+                        key={id}
+                        isActive={id === myEmojiId}
+                        py="0.5rem"
+                        px="0.75rem"
+                        onClick={(e) => handleEmojiLabelClick(e, id)}
+                      >
+                        {emoji}
+                      </EmojiLabel>
+                    );
+                  })}
+                </EmojiModal>
+              </EmojiButtonContainer>
 
-          <EmojiLabelList>
-            {emojis.map(({ id, count }) => {
-              const hasEmoji = count > 0;
+              <EmojiLabelList>
+                {emojis.map(({ id, count }) => {
+                  const hasEmoji = count > 0;
 
-              if (!hasEmoji) return;
+                  if (!hasEmoji) return;
 
-              const emoji = emojiList?.find(({ id: emojiId }) => emojiId === id)?.emoji;
+                  const emoji = emojiList?.find(({ id: emojiId }) => emojiId === id)?.emoji;
 
-              return (
-                <EmojiLabelItem key={id}>
-                  <EmojiLabel
-                    isActive={id === myEmojiId}
-                    py="0"
-                    px="0.75rem"
-                    onClick={(e) => handleEmojiLabelClick(e, id)}
-                  >
-                    {`${emoji} ${count}`}
-                  </EmojiLabel>
-                </EmojiLabelItem>
-              );
-            })}
-          </EmojiLabelList>
-        </Bottom>
+                  return (
+                    <EmojiLabelItem key={id}>
+                      <EmojiLabel
+                        isActive={id === myEmojiId}
+                        py="0"
+                        px="0.75rem"
+                        onClick={(e) => handleEmojiLabelClick(e, id)}
+                      >
+                        {`${emoji} ${count}`}
+                      </EmojiLabel>
+                    </EmojiLabelItem>
+                  );
+                })}
+              </EmojiLabelList>
+            </Bottom>
+          </>
+        )}
       </CommentLayout>
       {hasReplyIcon && isOpenReplyList && <ReplyList type={type} parentId={id} resumeId={resumeId} />}
     </>

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -376,12 +376,15 @@ const Comment = ({
                       right: 0;
                     `}
                   >
-                    <Dropdown.DropdownItem onClick={handleEditBtnClick}>수정</Dropdown.DropdownItem>
+                    <Dropdown.DropdownItem onClick={handleEditBtnClick} disabled={content === null}>
+                      수정
+                    </Dropdown.DropdownItem>
                     <Dropdown.DropdownItem
                       onClick={handleDeleteBtnClick}
                       $css={css`
                         color: ${theme.palette.red};
                       `}
+                      disabled={content === null}
                     >
                       삭제
                     </Dropdown.DropdownItem>

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -400,7 +400,7 @@ const Comment = ({
             resumeId={resumeId}
             resumePage={resumePage}
             questionId={id}
-            initLabelContent={labelContent}
+            initLabelContent={labelContent || null}
             initContent={content}
             onCancelEdit={() => setIsEdited(false)}
           />

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -395,7 +395,7 @@ const Comment = ({
         {isEdited && type === 'question' && (
           <QuestionEditForm
             resumeId={resumeId}
-            currentPageNum={resumePage}
+            resumePage={resumePage}
             questionId={id}
             initLabelContent={labelContent}
             initContent={content}

--- a/src/components/Comment/style.ts
+++ b/src/components/Comment/style.ts
@@ -13,7 +13,7 @@ const Top = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 `;
 
 const Info = styled.div`
@@ -59,7 +59,7 @@ const Time = styled.span`
 const CommentContent = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
 `;
 
 const SelectedLabel = styled.div`
@@ -67,13 +67,13 @@ const SelectedLabel = styled.div`
   justify-content: center;
   align-items: center;
   width: fit-content;
-  padding: 0 1rem;
+  padding: 0 0.5rem;
 
-  background: ${theme.color.accent.bg.strong};
+  background: ${theme.palette.green300};
   border-radius: 1rem;
 
-  ${theme.font.label}
-  color: ${theme.color.neutral.text.weak}
+  ${theme.font.body.weak}
+  color: ${theme.color.neutral.text.default}
 `;
 
 const Content = styled.span`

--- a/src/components/Dropdown/style.ts
+++ b/src/components/Dropdown/style.ts
@@ -42,6 +42,10 @@ const DropdownItem = styled.button<{ $css?: CSSProp }>`
   }
 
   ${({ $css }) => $css}
+
+  &:disabled {
+    opacity: 0.5;
+  }
 `;
 
 export { DropdownLayout, BackDrop, DropdownItem };

--- a/src/components/QuestionForm/QuestionAddForm/index.tsx
+++ b/src/components/QuestionForm/QuestionAddForm/index.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Button, Input, Textarea } from 'review-me-design-system';
 import { useUserContext } from '@contexts/userContext';
 import { usePostQuestion } from '@apis/questionApi';
-import { ButtonWrapper, KeywordLabel, QuestionFormLayout } from './style';
+import { ButtonWrapper, KeywordLabel, QuestionFormLayout } from '../style';
 
 interface Props {
   resumeId: number;
@@ -50,7 +50,7 @@ const QuestionForm = ({ resumeId, currentPageNum }: Props) => {
   };
 
   return (
-    <QuestionFormLayout onSubmit={handleSubmit}>
+    <QuestionFormLayout $type="add" onSubmit={handleSubmit}>
       <KeywordLabel>{labelContent}</KeywordLabel>
       <Input
         placeholder="예상질문 키워드"
@@ -58,7 +58,7 @@ const QuestionForm = ({ resumeId, currentPageNum }: Props) => {
         onChange={(e) => setLabelContent(e.target.value)}
       />
       <Textarea placeholder="예상질문" value={content} onChange={(e) => setContent(e.target.value)} />
-      <ButtonWrapper>
+      <ButtonWrapper $type="add">
         <Button variant="default" size="s">
           작성
         </Button>

--- a/src/components/QuestionForm/QuestionAddForm/index.tsx
+++ b/src/components/QuestionForm/QuestionAddForm/index.tsx
@@ -10,7 +10,7 @@ interface Props {
   resumePage: number;
 }
 
-const QuestionForm = ({ resumeId, resumePage }: Props) => {
+const QuestionAddForm = ({ resumeId, resumePage }: Props) => {
   const queryClient = useQueryClient();
   const { jwt } = useUserContext();
 
@@ -67,4 +67,4 @@ const QuestionForm = ({ resumeId, resumePage }: Props) => {
   );
 };
 
-export default QuestionForm;
+export default QuestionAddForm;

--- a/src/components/QuestionForm/QuestionAddForm/index.tsx
+++ b/src/components/QuestionForm/QuestionAddForm/index.tsx
@@ -7,10 +7,10 @@ import { ButtonWrapper, KeywordLabel, QuestionFormLayout } from '../style';
 
 interface Props {
   resumeId: number;
-  currentPageNum: number;
+  resumePage: number;
 }
 
-const QuestionForm = ({ resumeId, currentPageNum }: Props) => {
+const QuestionForm = ({ resumeId, resumePage }: Props) => {
   const queryClient = useQueryClient();
   const { jwt } = useUserContext();
 
@@ -34,13 +34,13 @@ const QuestionForm = ({ resumeId, currentPageNum }: Props) => {
         resumeId,
         content,
         labelContent: labelContent.trim(),
-        resumePage: currentPageNum,
+        resumePage,
         jwt,
       },
       {
         onSuccess: async () => {
           await queryClient.invalidateQueries({
-            queryKey: ['questionList', resumeId, currentPageNum],
+            queryKey: ['questionList', resumeId, resumePage],
           });
 
           resetForm();

--- a/src/components/QuestionForm/QuestionEditForm/index.tsx
+++ b/src/components/QuestionForm/QuestionEditForm/index.tsx
@@ -1,0 +1,106 @@
+import React, { FormEvent, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, Input, Textarea } from 'review-me-design-system';
+import { useUserContext } from '@contexts/userContext';
+import { usePatchQuestion } from '@apis/questionApi';
+import { ButtonWrapper, KeywordLabel, QuestionFormLayout } from '../style';
+
+interface Props {
+  resumeId: number;
+  currentPageNum: number;
+  questionId: number;
+  initLabelContent?: string | null;
+  initContent: string | null;
+  onCancelEdit: () => void;
+}
+
+const QuestionEditForm = ({
+  resumeId,
+  currentPageNum,
+  questionId,
+  initLabelContent,
+  initContent,
+  onCancelEdit,
+}: Props) => {
+  const queryClient = useQueryClient();
+  const { jwt } = useUserContext();
+
+  const [labelContent, setLabelContent] = useState<string>(initLabelContent || '');
+  const [content, setContent] = useState<string>(initContent || '');
+
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
+  const { mutate: editQuestion } = usePatchQuestion();
+
+  const resetForm = () => {
+    setLabelContent('');
+    setContent('');
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!jwt) return;
+
+    const hasContent = content.trim().length > 0;
+
+    if (!hasContent) {
+      contentRef.current?.focus();
+      return;
+    }
+
+    editQuestion(
+      {
+        resumeId,
+        questionId,
+        labelContent: labelContent.trim(),
+        content: content.trim(),
+        jwt,
+      },
+      {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: ['questionList', resumeId, currentPageNum],
+          });
+
+          resetForm();
+          onCancelEdit();
+        },
+      },
+    );
+  };
+
+  return (
+    <QuestionFormLayout $type="edit" onSubmit={handleSubmit}>
+      <KeywordLabel>{labelContent}</KeywordLabel>
+      <Input
+        placeholder="예상질문 키워드"
+        value={labelContent}
+        onChange={(e) => setLabelContent(e.target.value)}
+      />
+      <Textarea
+        ref={contentRef}
+        placeholder="예상질문"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <ButtonWrapper $type="edit">
+        <Button
+          variant="outline"
+          size="s"
+          onClick={(e) => {
+            e.preventDefault();
+            onCancelEdit();
+          }}
+        >
+          취소
+        </Button>
+        <Button variant="default" size="s">
+          수정
+        </Button>
+      </ButtonWrapper>
+    </QuestionFormLayout>
+  );
+};
+
+export default QuestionEditForm;

--- a/src/components/QuestionForm/QuestionEditForm/index.tsx
+++ b/src/components/QuestionForm/QuestionEditForm/index.tsx
@@ -7,7 +7,7 @@ import { ButtonWrapper, KeywordLabel, QuestionFormLayout } from '../style';
 
 interface Props {
   resumeId: number;
-  currentPageNum: number;
+  resumePage: number;
   questionId: number;
   initLabelContent?: string | null;
   initContent: string | null;
@@ -16,7 +16,7 @@ interface Props {
 
 const QuestionEditForm = ({
   resumeId,
-  currentPageNum,
+  resumePage,
   questionId,
   initLabelContent,
   initContent,
@@ -60,7 +60,7 @@ const QuestionEditForm = ({
       {
         onSuccess: async () => {
           await queryClient.invalidateQueries({
-            queryKey: ['questionList', resumeId, currentPageNum],
+            queryKey: ['questionList', resumeId, resumePage],
           });
 
           resetForm();

--- a/src/components/QuestionForm/QuestionEditForm/index.tsx
+++ b/src/components/QuestionForm/QuestionEditForm/index.tsx
@@ -9,7 +9,7 @@ interface Props {
   resumeId: number;
   resumePage: number;
   questionId: number;
-  initLabelContent?: string | null;
+  initLabelContent: string | null;
   initContent: string | null;
   onCancelEdit: () => void;
 }

--- a/src/components/QuestionForm/style.ts
+++ b/src/components/QuestionForm/style.ts
@@ -1,14 +1,14 @@
 import { theme } from 'review-me-design-system';
 import styled from 'styled-components';
 
-const QuestionFormLayout = styled.form`
+const QuestionFormLayout = styled.form<{ $type: 'add' | 'edit' }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  ${({ $type }) => $type === 'add' && 'padding: 0.75rem 1rem;'}
 
-  box-shadow: rgba(0, 0, 0, 0.07) 0 0 1.25rem;
+  ${({ $type }) => $type === 'add' && 'box-shadow: rgba(0, 0, 0, 0.07) 0 0 1.25rem'};
 `;
 
 const LabelList = styled.div`
@@ -18,9 +18,10 @@ const LabelList = styled.div`
   gap: 0.5rem;
 `;
 
-const ButtonWrapper = styled.div`
+const ButtonWrapper = styled.div<{ $type: 'add' | 'edit' }>`
   display: flex;
   justify-content: flex-end;
+  ${({ $type }) => $type === 'edit' && 'gap: 0.5rem;'}
   width: 100%;
 `;
 

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -6,7 +6,7 @@ import Comment from '@components/Comment';
 import CommentForm from '@components/CommentForm';
 import FeedbackForm from '@components/FeedbackForm';
 import PdfViewer from '@components/PdfViewer';
-import QuestionForm from '@components/QuestionForm';
+import QuestionAddForm from '@components/QuestionForm/QuestionAddForm';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import usePdf from '@hooks/usePdf';
 import { useUserContext } from '@contexts/userContext';
@@ -199,7 +199,7 @@ const ResumeDetail = () => {
             <FeedbackForm resumeId={Number(resumeId)} currentPageNum={currentPageNum} />
           )}
           {currentTab === 'question' && resumeId && (
-            <QuestionForm resumeId={Number(resumeId)} currentPageNum={currentPageNum} />
+            <QuestionAddForm resumeId={Number(resumeId)} currentPageNum={currentPageNum} />
           )}
           {currentTab === 'comment' && resumeId && <CommentForm resumeId={Number(resumeId)} />}
         </FeedbackAndQuestion>

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -199,7 +199,7 @@ const ResumeDetail = () => {
             <FeedbackForm resumeId={Number(resumeId)} currentPageNum={currentPageNum} />
           )}
           {currentTab === 'question' && resumeId && (
-            <QuestionAddForm resumeId={Number(resumeId)} currentPageNum={currentPageNum} />
+            <QuestionAddForm resumeId={Number(resumeId)} resumePage={currentPageNum} />
           )}
           {currentTab === 'comment' && resumeId && <CommentForm resumeId={Number(resumeId)} />}
         </FeedbackAndQuestion>


### PR DESCRIPTION
## 개요

## 작업 사항

- QuestionForm 컴포넌트에서 QuestionAddForm, QuestionEditForm으로 구체화하기
- 이미 삭제된 예상질문이라면, Dropdown에서 `수정` 버튼과 `삭제` 버튼을 `disabled`한다.
- Dropdown의 수정을 클릭시, 예상질문을 수정할 수 있는 QuestionEditForm이 표시된다. 
  - 라벨과 댓글 내용을 수정할 수 있다.
- QuestionEditForm에서 취소 버튼을 클릭시, form이 닫힌다.
- labelContent와 content를 입력한 상태에서 수정을 클릭하면, 서버에 수정 요청을 보내고 question 목록을 다시 불러온다.
  - content에 값을 입력하지 않으면 focus한다.

## 이슈 번호

close #123 
