### PR TITLE
[FE] 피드백 수정 기능

### DIFF
--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -232,6 +232,47 @@ export const useDeleteFeedback = () => {
   return useMutation({ mutationFn: deleteFeedback });
 };
 
+// PATCH 피드백 수정
+export const patchFeedback = async ({
+  resumeId,
+  feedbackId,
+  labelId,
+  content,
+  jwt,
+}: {
+  resumeId: number;
+  feedbackId: number;
+  labelId?: number;
+  content: string;
+  jwt: string;
+}) => {
+  const requestBody: { labelId?: number; content: string } = {
+    content,
+  };
+  if (labelId) requestBody.labelId = labelId;
+
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/feedback/${feedbackId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const usePatchFeedback = () => {
+  return useMutation({ mutationFn: patchFeedback });
+};
+
 // PATCH 피드백 체크 상태 수정
 export const patchFeedbackCheck = async ({
   resumeId,

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -323,7 +323,7 @@ const Comment = ({
           {!isEdited && (
             <ButtonsContainer>
               {hasBookMarkIcon && (
-                <IconButton onClick={handleBookMarkClick}>
+                <IconButton onClick={handleBookMarkClick} disabled={content === null}>
                   {bookmarked ? (
                     <Icon
                       iconName="filledBookMark"
@@ -342,7 +342,7 @@ const Comment = ({
                 </IconButton>
               )}
               {hasCheckMarkIcon && (
-                <IconButton onClick={handleCheckMarkClick}>
+                <IconButton onClick={handleCheckMarkClick} disabled={content === null}>
                   {checked ? (
                     <Icon
                       iconName="filledCheckMark"
@@ -362,7 +362,7 @@ const Comment = ({
               )}
               {hasMoreIcon && (
                 <MoreIconContainer>
-                  <IconButton onClick={openDropdown}>
+                  <IconButton onClick={openDropdown} disabled={content === null}>
                     <Icon
                       iconName="more"
                       width={ICON_SIZE}
@@ -379,15 +379,12 @@ const Comment = ({
                       right: 0;
                     `}
                   >
-                    <Dropdown.DropdownItem onClick={handleEditBtnClick} disabled={content === null}>
-                      수정
-                    </Dropdown.DropdownItem>
+                    <Dropdown.DropdownItem onClick={handleEditBtnClick}>수정</Dropdown.DropdownItem>
                     <Dropdown.DropdownItem
                       onClick={handleDeleteBtnClick}
                       $css={css`
                         color: ${theme.palette.red};
                       `}
-                      disabled={content === null}
                     >
                       삭제
                     </Dropdown.DropdownItem>
@@ -436,6 +433,7 @@ const Comment = ({
                 <EmojiButton
                   onMouseEnter={() => changeHoverState(true)}
                   onMouseLeave={() => changeHoverState(false)}
+                  disabled={content === null}
                 >
                   <Icon iconName="emoji" />
                 </EmojiButton>

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -3,6 +3,7 @@ import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { Icon, Label as EmojiLabel, theme } from 'review-me-design-system';
 import { css } from 'styled-components';
 import Dropdown from '@components/Dropdown';
+import FeedbackEditForm from '@components/FeedbackForm/FeedbackEditForm';
 import QuestionEditForm from '@components/QuestionForm/QuestionEditForm';
 import ReplyList from '@components/ReplyList';
 import useDropdown from '@hooks/useDropdown';
@@ -395,6 +396,16 @@ const Comment = ({
           )}
         </Top>
 
+        {isEdited && type === 'feedback' && (
+          <FeedbackEditForm
+            resumeId={resumeId}
+            resumePage={resumePage}
+            feedbackId={id}
+            initLabelContent={labelContent || null}
+            initContent={content}
+            onCancelEdit={() => setIsEdited(false)}
+          />
+        )}
         {isEdited && type === 'question' && (
           <QuestionEditForm
             resumeId={resumeId}

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -233,8 +233,9 @@ const Comment = ({
       deleteFeedback(
         { resumeId, feedbackId: id, jwt },
         {
-          onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['feedbackList', resumeId, resumePage] });
+          onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: ['feedbackList', resumeId, resumePage] });
+            closeDropdown();
           },
         },
       );
@@ -243,8 +244,9 @@ const Comment = ({
       deleteQuestion(
         { resumeId, questionId: id, jwt },
         {
-          onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['questionList', resumeId, resumePage] });
+          onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: ['questionList', resumeId, resumePage] });
+            closeDropdown();
           },
         },
       );

--- a/src/components/Comment/style.ts
+++ b/src/components/Comment/style.ts
@@ -34,6 +34,11 @@ const IconButton = styled.button`
   height: 1.5rem;
   background-color: transparent;
   cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
 `;
 
 const CommentInfo = styled.div`
@@ -124,6 +129,11 @@ const EmojiButton = styled.button`
   }
 
   cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
 `;
 
 const EmojiLabelList = styled.ul`

--- a/src/components/FeedbackForm/FeedbackAddForm/index.tsx
+++ b/src/components/FeedbackForm/FeedbackAddForm/index.tsx
@@ -61,7 +61,16 @@ const FeedbackAddForm = ({ resumeId, resumePage }: Props) => {
               isActive={labelId === id}
               py="0.25rem"
               px="0.75rem"
-              onClick={() => setLabelId(id)}
+              onClick={() => {
+                const isLabelIdSameAsSelected = labelId === id;
+
+                if (isLabelIdSameAsSelected) {
+                  setLabelId(undefined);
+                  return;
+                }
+
+                setLabelId(id);
+              }}
             >
               {label}
             </Label>

--- a/src/components/FeedbackForm/FeedbackAddForm/index.tsx
+++ b/src/components/FeedbackForm/FeedbackAddForm/index.tsx
@@ -4,14 +4,14 @@ import { Button, Label, Textarea } from 'review-me-design-system';
 import { useUserContext } from '@contexts/userContext';
 import { usePostFeedback } from '@apis/feedbackApi';
 import { useLabelList } from '@apis/utilApi';
-import { ButtonWrapper, FeedbackFormLayout, LabelList } from './style';
+import { ButtonWrapper, FeedbackFormLayout, LabelList } from '../style';
 
 interface Props {
   resumeId: number;
-  currentPageNum: number;
+  resumePage: number;
 }
 
-const FeedbackForm = ({ resumeId, currentPageNum }: Props) => {
+const FeedbackAddForm = ({ resumeId, resumePage }: Props) => {
   const queryClient = useQueryClient();
   const { jwt } = useUserContext();
 
@@ -36,13 +36,13 @@ const FeedbackForm = ({ resumeId, currentPageNum }: Props) => {
         resumeId,
         content: content,
         labelId,
-        resumePage: currentPageNum,
+        resumePage,
         jwt,
       },
       {
         onSuccess: async () => {
           await queryClient.invalidateQueries({
-            queryKey: ['feedbackList', resumeId, currentPageNum],
+            queryKey: ['feedbackList', resumeId, resumePage],
           });
 
           resetForm();
@@ -52,7 +52,7 @@ const FeedbackForm = ({ resumeId, currentPageNum }: Props) => {
   };
 
   return (
-    <FeedbackFormLayout onSubmit={handleSubmit}>
+    <FeedbackFormLayout $type="add" onSubmit={handleSubmit}>
       <LabelList>
         {labelList?.map(({ id, label }) => {
           return (
@@ -69,7 +69,7 @@ const FeedbackForm = ({ resumeId, currentPageNum }: Props) => {
         })}
       </LabelList>
       <Textarea placeholder="피드백" value={content} onChange={(e) => setContent(e.target.value)} />
-      <ButtonWrapper>
+      <ButtonWrapper $type="add">
         <Button variant="default" size="s">
           작성
         </Button>
@@ -78,4 +78,4 @@ const FeedbackForm = ({ resumeId, currentPageNum }: Props) => {
   );
 };
 
-export default FeedbackForm;
+export default FeedbackAddForm;

--- a/src/components/FeedbackForm/FeedbackEditForm/index.tsx
+++ b/src/components/FeedbackForm/FeedbackEditForm/index.tsx
@@ -1,0 +1,128 @@
+import React, { FormEvent, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, Label, Textarea } from 'review-me-design-system';
+import { useUserContext } from '@contexts/userContext';
+import { usePatchFeedback } from '@apis/feedbackApi';
+import { useLabelList } from '@apis/utilApi';
+import { ButtonWrapper, FeedbackFormLayout, LabelList } from '../style';
+
+interface Props {
+  resumeId: number;
+  resumePage: number;
+  feedbackId: number;
+  initLabelContent: string | null;
+  initContent: string | null;
+  onCancelEdit: () => void;
+}
+
+const FeedbackEditForm = ({
+  resumeId,
+  resumePage,
+  feedbackId,
+  initLabelContent,
+  initContent,
+  onCancelEdit,
+}: Props) => {
+  const queryClient = useQueryClient();
+  const { jwt } = useUserContext();
+
+  const { data: labelList } = useLabelList();
+  const initLabelId = labelList?.find(({ label }) => label === initLabelContent)?.id;
+
+  const [labelId, setLabelId] = useState<number | undefined>(initLabelId);
+  const [content, setContent] = useState<string>(initContent || '');
+
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
+  const { mutate: editFeedback } = usePatchFeedback();
+
+  const resetForm = () => {
+    setLabelId(undefined);
+    setContent('');
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!jwt) return;
+
+    const hasContent = content.trim().length > 0;
+
+    if (!hasContent) {
+      contentRef.current?.focus();
+      return;
+    }
+
+    editFeedback(
+      {
+        resumeId,
+        feedbackId,
+        labelId,
+        content: content.trim(),
+        jwt,
+      },
+      {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: ['feedbackList', resumeId, resumePage],
+          });
+
+          resetForm();
+          onCancelEdit();
+        },
+      },
+    );
+  };
+
+  return (
+    <FeedbackFormLayout $type="edit" onSubmit={handleSubmit}>
+      <LabelList>
+        {labelList?.map(({ id, label }) => {
+          return (
+            <Label
+              key={id}
+              isActive={labelId === id}
+              py="0.25rem"
+              px="0.75rem"
+              onClick={() => {
+                const isLabelIdSameAsSelected = labelId === id;
+
+                if (isLabelIdSameAsSelected) {
+                  setLabelId(undefined);
+                  return;
+                }
+
+                setLabelId(id);
+              }}
+            >
+              {label}
+            </Label>
+          );
+        })}
+      </LabelList>
+      <Textarea
+        ref={contentRef}
+        placeholder="피드백"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <ButtonWrapper $type="edit">
+        <Button
+          variant="outline"
+          size="s"
+          onClick={(e) => {
+            e.preventDefault();
+            onCancelEdit();
+          }}
+        >
+          취소
+        </Button>
+        <Button variant="default" size="s">
+          수정
+        </Button>
+      </ButtonWrapper>
+    </FeedbackFormLayout>
+  );
+};
+
+export default FeedbackEditForm;

--- a/src/components/FeedbackForm/style.ts
+++ b/src/components/FeedbackForm/style.ts
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
-const FeedbackFormLayout = styled.form`
+const FeedbackFormLayout = styled.form<{ $type: 'add' | 'edit' }>`
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  ${({ $type }) => $type === 'add' && 'padding: 0.75rem 1rem;'}
 
-  box-shadow: rgba(0, 0, 0, 0.07) 0 0 1.25rem;
+  ${({ $type }) => $type === 'add' && 'box-shadow: rgba(0, 0, 0, 0.07) 0 0 1.25rem'};
 `;
 
 const LabelList = styled.div`
@@ -17,9 +17,10 @@ const LabelList = styled.div`
   gap: 0.5rem;
 `;
 
-const ButtonWrapper = styled.div`
+const ButtonWrapper = styled.div<{ $type: 'add' | 'edit' }>`
   display: flex;
   justify-content: flex-end;
+  ${({ $type }) => $type === 'edit' && 'gap: 0.5rem;'}
   width: 100%;
 `;
 

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -4,7 +4,7 @@ import { Icon } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
 import CommentForm from '@components/CommentForm';
-import FeedbackForm from '@components/FeedbackForm';
+import FeedbackAddForm from '@components/FeedbackForm/FeedbackAddForm';
 import PdfViewer from '@components/PdfViewer';
 import QuestionAddForm from '@components/QuestionForm/QuestionAddForm';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
@@ -196,7 +196,7 @@ const ResumeDetail = () => {
           </CommentList>
 
           {currentTab === 'feedback' && resumeId && (
-            <FeedbackForm resumeId={Number(resumeId)} currentPageNum={currentPageNum} />
+            <FeedbackAddForm resumeId={Number(resumeId)} resumePage={currentPageNum} />
           )}
           {currentTab === 'question' && resumeId && (
             <QuestionAddForm resumeId={Number(resumeId)} resumePage={currentPageNum} />


### PR DESCRIPTION
## 개요

## 작업 사항

- Comment 컴포넌트에서 Dropdown의 삭제 버튼을 클릭할 경우, Dropdown이 닫히는 기능
- Comment 컴포넌트의 content 값이 null일 경우, 이모지 / more 버튼 / check 버튼 / bookmark 버튼 disabled로 처리

- FeedbackForm 컴포넌트에서 FeedbackAddForm, FeedbackEditForm으로 구체화하기
- Dropdown의 수정을 클릭시, 피드백을 수정할 수 있는 FeedbackEditForm이 표시된다.
  - 라벨과 댓글 내용을 수정할 수 있다.
- 이미 삭제된 피드백이라면 Dropdown의 수정 버튼과 삭제 버튼을 disabled한다.

FeedbackEditForm

- 취소 버튼을 클릭시, form이 닫힌다.
- labelId와 content를 입력한 상태에서 수정을 클릭하면, 서버에 수정 요청을 보내고 피드백 목록을 다시 불러온다.
- content에 값을 입력하지 않으면 focus한다. (=필수값이다.)
- labelId는 선택할 수 있다. (=필수값이 아니다.)

## 이슈 번호

close #125 