### PR TITLE
[FE] 댓글 수정 기능

### DIFF
--- a/src/apis/commentApi.ts
+++ b/src/apis/commentApi.ts
@@ -135,6 +135,40 @@ export const useDeleteComment = () => {
   return useMutation({ mutationFn: deleteComment });
 };
 
+// PATCH 댓글 수정
+export const patchComment = async ({
+  resumeId,
+  commentId,
+  content,
+  jwt,
+}: {
+  resumeId: number;
+  commentId: number;
+  content: string;
+  jwt: string;
+}) => {
+  const response = await fetch(`${REQUEST_URL.RESUME}/${resumeId}/comment/${commentId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
+    body: JSON.stringify({ content }),
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const usePatchComment = () => {
+  return useMutation({ mutationFn: patchComment });
+};
+
 // PATCH 댓글 이모지 수정
 export const patchEmojiAboutComment = async ({
   resumeId,

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -258,6 +258,7 @@ const Comment = ({
         {
           onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['commentList', resumeId] });
+            closeDropdown();
           },
         },
       );

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -2,6 +2,7 @@ import React, { MouseEvent, useState } from 'react';
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { Icon, Label as EmojiLabel, theme } from 'review-me-design-system';
 import { css } from 'styled-components';
+import CommentEditForm from '@components/CommentForm/CommentEditForm';
 import Dropdown from '@components/Dropdown';
 import FeedbackEditForm from '@components/FeedbackForm/FeedbackEditForm';
 import QuestionEditForm from '@components/QuestionForm/QuestionEditForm';
@@ -412,6 +413,14 @@ const Comment = ({
             questionId={id}
             initLabelContent={labelContent || null}
             initContent={content}
+            onCancelEdit={() => setIsEdited(false)}
+          />
+        )}
+        {isEdited && type === 'comment' && (
+          <CommentEditForm
+            resumeId={resumeId}
+            commentId={id}
+            initContent={content || ''}
             onCancelEdit={() => setIsEdited(false)}
           />
         )}

--- a/src/components/CommentForm/CommentAddForm/index.tsx
+++ b/src/components/CommentForm/CommentAddForm/index.tsx
@@ -3,13 +3,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Button, Textarea } from 'review-me-design-system';
 import { useUserContext } from '@contexts/userContext';
 import { usePostComment } from '@apis/commentApi';
-import { ButtonWrapper, CommentFormLayout } from './style';
+import { ButtonWrapper, CommentFormLayout } from '../style';
 
 interface Props {
   resumeId: number;
 }
 
-const CommentForm = ({ resumeId }: Props) => {
+const CommentAddForm = ({ resumeId }: Props) => {
   const queryClient = useQueryClient();
   const { jwt } = useUserContext();
 
@@ -45,9 +45,9 @@ const CommentForm = ({ resumeId }: Props) => {
   };
 
   return (
-    <CommentFormLayout onSubmit={handleSubmit}>
+    <CommentFormLayout $type="add" onSubmit={handleSubmit}>
       <Textarea placeholder="댓글" value={content} onChange={(e) => setContent(e.target.value)} />
-      <ButtonWrapper>
+      <ButtonWrapper $type="add">
         <Button variant="default" size="s">
           작성
         </Button>
@@ -56,4 +56,4 @@ const CommentForm = ({ resumeId }: Props) => {
   );
 };
 
-export default CommentForm;
+export default CommentAddForm;

--- a/src/components/CommentForm/CommentEditForm/index.tsx
+++ b/src/components/CommentForm/CommentEditForm/index.tsx
@@ -1,0 +1,74 @@
+import React, { FormEvent, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, Textarea } from 'review-me-design-system';
+import { useUserContext } from '@contexts/userContext';
+import { usePatchComment } from '@apis/commentApi';
+import { ButtonWrapper, CommentFormLayout } from '../style';
+
+interface Props {
+  resumeId: number;
+  commentId: number;
+  initContent: string;
+  onCancelEdit: () => void;
+}
+
+const CommentEditForm = ({ resumeId, commentId, initContent, onCancelEdit }: Props) => {
+  const queryClient = useQueryClient();
+  const { jwt } = useUserContext();
+
+  const [content, setContent] = useState<string>(initContent);
+
+  const { mutate: editComment } = usePatchComment();
+
+  const resetForm = () => {
+    setContent('');
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!jwt || !content) return;
+
+    editComment(
+      {
+        resumeId,
+        commentId,
+        content,
+        jwt,
+      },
+      {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: ['commentList', resumeId],
+          });
+
+          resetForm();
+          onCancelEdit();
+        },
+      },
+    );
+  };
+
+  return (
+    <CommentFormLayout $type="edit" onSubmit={handleSubmit}>
+      <Textarea value={content} onChange={(e) => setContent(e.target.value)} />
+      <ButtonWrapper $type="edit">
+        <Button
+          variant="outline"
+          size="s"
+          onClick={(e) => {
+            e.preventDefault();
+            onCancelEdit();
+          }}
+        >
+          취소
+        </Button>
+        <Button variant="default" size="s">
+          수정
+        </Button>
+      </ButtonWrapper>
+    </CommentFormLayout>
+  );
+};
+
+export default CommentEditForm;

--- a/src/components/CommentForm/CommentEditForm/index.tsx
+++ b/src/components/CommentForm/CommentEditForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState } from 'react';
+import React, { FormEvent, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Textarea } from 'review-me-design-system';
 import { useUserContext } from '@contexts/userContext';
@@ -18,6 +18,8 @@ const CommentEditForm = ({ resumeId, commentId, initContent, onCancelEdit }: Pro
 
   const [content, setContent] = useState<string>(initContent);
 
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
   const { mutate: editComment } = usePatchComment();
 
   const resetForm = () => {
@@ -27,7 +29,14 @@ const CommentEditForm = ({ resumeId, commentId, initContent, onCancelEdit }: Pro
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!jwt || !content) return;
+    if (!jwt) return;
+
+    const hasContent = content.trim().length > 0;
+
+    if (!hasContent) {
+      contentRef.current?.focus();
+      return;
+    }
 
     editComment(
       {
@@ -51,7 +60,7 @@ const CommentEditForm = ({ resumeId, commentId, initContent, onCancelEdit }: Pro
 
   return (
     <CommentFormLayout $type="edit" onSubmit={handleSubmit}>
-      <Textarea value={content} onChange={(e) => setContent(e.target.value)} />
+      <Textarea ref={contentRef} value={content} onChange={(e) => setContent(e.target.value)} />
       <ButtonWrapper $type="edit">
         <Button
           variant="outline"

--- a/src/components/CommentForm/style.ts
+++ b/src/components/CommentForm/style.ts
@@ -1,18 +1,19 @@
 import styled from 'styled-components';
 
-const CommentFormLayout = styled.form`
+const CommentFormLayout = styled.form<{ $type: 'add' | 'edit' }>`
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  ${({ $type }) => $type === 'add' && 'padding: 0.75rem 1rem;'}
 
-  box-shadow: rgba(0, 0, 0, 0.07) 0 0 1.25rem;
+  ${({ $type }) => $type === 'add' && 'box-shadow: rgba(0, 0, 0, 0.07) 0 0 1.25rem'};
 `;
 
-const ButtonWrapper = styled.div`
+const ButtonWrapper = styled.div<{ $type: 'add' | 'edit' }>`
   display: flex;
   justify-content: flex-end;
+  ${({ $type }) => $type === 'edit' && 'gap: 0.5rem;'}
   width: 100%;
 `;
 

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { Icon } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
-import CommentForm from '@components/CommentForm';
+import CommentAddForm from '@components/CommentForm/CommentAddForm';
 import FeedbackAddForm from '@components/FeedbackForm/FeedbackAddForm';
 import PdfViewer from '@components/PdfViewer';
 import QuestionAddForm from '@components/QuestionForm/QuestionAddForm';
@@ -201,7 +201,7 @@ const ResumeDetail = () => {
           {currentTab === 'question' && resumeId && (
             <QuestionAddForm resumeId={Number(resumeId)} resumePage={currentPageNum} />
           )}
-          {currentTab === 'comment' && resumeId && <CommentForm resumeId={Number(resumeId)} />}
+          {currentTab === 'comment' && resumeId && <CommentAddForm resumeId={Number(resumeId)} />}
         </FeedbackAndQuestion>
       </ResumeContentWrapper>
     </Main>


### PR DESCRIPTION
## 개요

댓글 수정 기능 구현

## 작업 사항

- 댓글을 삭제하고, Dropdown이 닫힌다.

- `CommentForm` 컴포넌트에서 `CommentAddForm`, `CommentEditForm`으로 구체화하기
- `Dropdown`의 `수정`을 클릭시, 댓글을 수정할 수 있는 `CommentEditForm`이 표시된다.
    - 댓글 내용을 수정할 수 있다.


`CommentEditForm`
- `취소` 버튼을 클릭시, form이 닫힌다.
- `content`를 입력한 상태에서 `수정`을 클릭하면, 서버에 수정 요청을 보내고 댓글 목록을 다시 불러온다.
  - `content`에 값을 입력하지 않으면 focus한다. (=필수값이다.)


## 이슈 번호

close #127 
