### PR TITLE
[FE] 로그인 관련 API 수정에 따라 리팩토링 

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -3,12 +3,8 @@ import { useUserContext } from '@contexts/userContext';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse } from './response.types';
 
-// POST jwt 발급
-interface GetJwt {
-  jwt: string;
-}
-
-const getJwt = async (code: string) => {
+// POST code를 통해 refresh token만 생성
+const createRefreshToken = async (code: string) => {
   const response = await fetch(`${REQUEST_URL.OAUTH}`, {
     method: 'POST',
     headers: {
@@ -22,14 +18,14 @@ const getJwt = async (code: string) => {
     throw response;
   }
 
-  const { data }: ApiResponse<GetJwt> = await response.json();
+  const { data }: ApiResponse<null> = await response.json();
 
   return data;
 };
 
-export const useJwt = () => {
+export const usePostRefreshToken = () => {
   return useMutation({
-    mutationFn: getJwt,
+    mutationFn: createRefreshToken,
   });
 };
 

--- a/src/components/Comment/Reply/index.tsx
+++ b/src/components/Comment/Reply/index.tsx
@@ -79,8 +79,7 @@ const Reply = ({
 }: Props) => {
   const { isHover, changeHoverState } = useHover();
   const { isDropdownOpen, openDropdown, closeDropdown } = useDropdown();
-  const { jwt, isLoggedIn, user } = useUserContext();
-  const isAuthenticated = jwt && isLoggedIn;
+  const { jwt, user } = useUserContext();
 
   const ICON_SIZE = 24;
 
@@ -94,7 +93,7 @@ const Reply = ({
   const queryClient = useQueryClient();
 
   const handleEmojiLabelClick = (e: MouseEvent<HTMLDivElement>, clickedEmojiId: number) => {
-    if (!isAuthenticated) return;
+    if (!jwt) return;
 
     const shouldDeleteEmoji = myEmojiId === clickedEmojiId;
 

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -97,8 +97,7 @@ const Comment = ({
   emojis,
   myEmojiId,
 }: Props) => {
-  const { jwt, isLoggedIn, user } = useUserContext();
-  const isAuthenticated = jwt && isLoggedIn;
+  const { jwt, user } = useUserContext();
   const { isHover, changeHoverState } = useHover();
   const { isDropdownOpen, openDropdown, closeDropdown } = useDropdown();
   const [isOpenReplyList, setIsOpenReplyList] = useState<boolean>(false);
@@ -127,7 +126,7 @@ const Comment = ({
   const queryClient = useQueryClient();
 
   const handleEmojiLabelClick = (e: MouseEvent<HTMLDivElement>, clickedEmojiId: number) => {
-    if (!isAuthenticated) return;
+    if (!jwt) return;
 
     const shouldDeleteEmoji = myEmojiId === clickedEmojiId;
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -58,6 +58,11 @@ const Header = () => {
     window.location.assign(GITHUB_OAUTH_URI);
   };
 
+  const handleLogout = () => {
+    logout();
+    navigate(ROUTE_PATH.ROOT);
+  };
+
   return (
     <>
       <HeaderLayout>
@@ -111,7 +116,7 @@ const Header = () => {
                     </Button>
                   )}
                   {isLoggedIn && (
-                    <Button variant="outline" size="s" onClick={logout}>
+                    <Button variant="outline" size="s" onClick={handleLogout}>
                       로그아웃
                     </Button>
                   )}
@@ -155,7 +160,7 @@ const Header = () => {
               <Icon iconName="person" color={theme.color.accent.text.strong} width={32} height={32} />
             </IconButton>
             {!isSMDevice && (
-              <Button variant="default" size="s" onClick={isLoggedIn ? logout : handleLogin}>
+              <Button variant="default" size="s" onClick={isLoggedIn ? handleLogout : handleLogin}>
                 {isLoggedIn ? '로그아웃' : '로그인'}
               </Button>
             )}

--- a/src/components/ReplyList/index.tsx
+++ b/src/components/ReplyList/index.tsx
@@ -14,8 +14,7 @@ interface Props {
 }
 
 const ReplyList = ({ type, parentId, resumeId }: Props) => {
-  const { jwt, isLoggedIn } = useUserContext();
-  const isAuthenticated = jwt && isLoggedIn;
+  const { jwt } = useUserContext();
 
   const { data: feedbackReplyList, fetchNextPage: fetchNextFeedbackReplyList } = useFeedbackReplyList({
     resumeId,
@@ -63,7 +62,7 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!isAuthenticated) return;
+    if (!jwt) return;
     if (content.length === 0) return;
 
     if (type === 'feedback') addFeedbackReply({ resumeId, parentFeedbackId: parentId, content, jwt });

--- a/src/components/TokenRefresh/index.tsx
+++ b/src/components/TokenRefresh/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const TokenRefresh = ({ children }: Props) => {
   const { getRenewedJwtQuery } = useAuth();
-  const { isSuccess, refetch, isFetched, data, isError, status, error } = getRenewedJwtQuery;
+  const { refetch, data, isError, isSuccess, isFetched } = getRenewedJwtQuery;
   const { login, logout, isLoggedIn, jwt } = useUserContext();
   const navigate = useNavigate();
 
@@ -24,15 +24,12 @@ const TokenRefresh = ({ children }: Props) => {
       return;
     }
 
-    const isJwtRenewalSuccessful = isSuccess && data;
-    const isJwtRenewalFailed = isError;
-
-    if (isJwtRenewalSuccessful) {
+    if (isSuccess && data) {
       login(data.jwt);
     }
-    if (isJwtRenewalFailed) {
+    if (isError) {
       logout();
-      alert(error?.message);
+      alert('다시 로그인해주세요!');
       navigate(ROUTE_PATH.ROOT);
     }
   }, [isSuccess, isError, isFetched, data, isLoggedIn]);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,10 +1,10 @@
-import { useJwt, useRenewJwt } from '@apis/login';
+import { usePostRefreshToken, useRenewJwt } from '@apis/login';
 
 const useAuth = () => {
-  const createJwtQuery = useJwt();
+  const createRefreshTokenQuery = usePostRefreshToken();
   const getRenewedJwtQuery = useRenewJwt();
 
-  return { createJwtQuery, getRenewedJwtQuery };
+  return { createRefreshTokenQuery, getRenewedJwtQuery };
 };
 
 export default useAuth;

--- a/src/pages/SocialLogin/index.tsx
+++ b/src/pages/SocialLogin/index.tsx
@@ -2,21 +2,21 @@ import React, { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import useAuth from '@hooks/useAuth';
 import { useUserContext } from '@contexts/userContext';
-import { ROUTE_PATH } from '@constants';
+import { IS_LOGGED_IN_KEY, ROUTE_PATH } from '@constants';
 
 const SocialLogin = () => {
   const [searchParams] = useSearchParams();
   const code = searchParams.get('code');
 
-  const { createJwtQuery } = useAuth();
-  const { logout, login } = useUserContext();
+  const { createRefreshTokenQuery } = useAuth();
+  const { logout } = useUserContext();
   const navigate = useNavigate();
 
   useEffect(() => {
     if (code)
-      createJwtQuery.mutate(code, {
-        onSuccess: (data) => {
-          login(data.jwt);
+      createRefreshTokenQuery.mutate(code, {
+        onSuccess: () => {
+          localStorage.setItem(IS_LOGGED_IN_KEY, 'true');
         },
         onError: () => {
           alert('로그인에 실패했습니다.');


### PR DESCRIPTION
## 개요

authorization code를 통해 refresh token를 받고, refresh token을 통해 새로운 jwt를 받도록 API가 수정됐다.

## 작업 사항

- refresh token을 요청하는 hook과 함수 네이밍 변경
- Header 컴포넌트의 로그아웃을 누를 경우, 메인페이지로 이동
- TokenRefresh에서 if문 수정 및 에러 메세지 변경

## 이슈 번호

close #129 
