### PR TITLE
[FE] 피드백 대댓글 / 예상질문 대댓글 수정 기능

### DIFF
--- a/src/components/Comment/Reply/index.tsx
+++ b/src/components/Comment/Reply/index.tsx
@@ -1,8 +1,9 @@
-import React, { MouseEvent } from 'react';
+import React, { MouseEvent, useState } from 'react';
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import { Icon, Label as EmojiLabel, theme } from 'review-me-design-system';
 import { css } from 'styled-components';
 import Dropdown from '@components/Dropdown';
+import ReplyEditForm from '@components/ReplyForm/ReplyEditForm';
 import useDropdown from '@hooks/useDropdown';
 import useEmojiUpdate from '@hooks/useEmojiUpdate';
 import useHover from '@hooks/useHover';
@@ -80,6 +81,8 @@ const Reply = ({
   const { isHover, changeHoverState } = useHover();
   const { isDropdownOpen, openDropdown, closeDropdown } = useDropdown();
   const { jwt, user } = useUserContext();
+
+  const [isEdited, setIsEdited] = useState<boolean>(false);
 
   const ICON_SIZE = 24;
 
@@ -198,7 +201,7 @@ const Reply = ({
           </CommentInfo>
         </Info>
 
-        {hasMoreIcon && (
+        {!isEdited && hasMoreIcon && (
           <MoreIconContainer>
             <IconButton onClick={openDropdown}>
               <Icon
@@ -217,7 +220,7 @@ const Reply = ({
                 right: 0;
               `}
             >
-              <Dropdown.DropdownItem>수정</Dropdown.DropdownItem>
+              <Dropdown.DropdownItem onClick={() => setIsEdited(true)}>수정</Dropdown.DropdownItem>
               <Dropdown.DropdownItem
                 onClick={handleDeleteBtnClick}
                 $css={css`
@@ -231,62 +234,79 @@ const Reply = ({
         )}
       </Top>
 
-      <CommentContent>
-        <Content>{content}</Content>
-      </CommentContent>
+      {isEdited && (
+        <ReplyEditForm
+          type={type}
+          resumeId={resumeId}
+          parentId={parentId}
+          id={id}
+          onCancelEdit={() => {
+            setIsEdited(false);
+            closeDropdown();
+          }}
+        />
+      )}
 
-      <Bottom>
-        <EmojiButtonContainer>
-          <EmojiButton
-            onMouseEnter={() => changeHoverState(true)}
-            onMouseLeave={() => changeHoverState(false)}
-          >
-            <Icon iconName="emoji" />
-          </EmojiButton>
-          <EmojiModal
-            className={isHover ? 'active' : ''}
-            onMouseEnter={() => changeHoverState(true)}
-            onMouseLeave={() => changeHoverState(false)}
-          >
-            {emojiList?.map(({ id, emoji }) => {
-              return (
-                <EmojiLabel
-                  key={id}
-                  isActive={id === myEmojiId}
-                  py="0.5rem"
-                  px="0.75rem"
-                  onClick={(e) => handleEmojiLabelClick(e, id)}
-                >
-                  {emoji}
-                </EmojiLabel>
-              );
-            })}
-          </EmojiModal>
-        </EmojiButtonContainer>
+      {!isEdited && (
+        <>
+          <CommentContent>
+            <Content>{content}</Content>
+          </CommentContent>
 
-        <EmojiLabelList>
-          {emojis.map(({ id, count }) => {
-            const hasEmoji = count > 0;
+          <Bottom>
+            <EmojiButtonContainer>
+              <EmojiButton
+                onMouseEnter={() => changeHoverState(true)}
+                onMouseLeave={() => changeHoverState(false)}
+              >
+                <Icon iconName="emoji" />
+              </EmojiButton>
+              <EmojiModal
+                className={isHover ? 'active' : ''}
+                onMouseEnter={() => changeHoverState(true)}
+                onMouseLeave={() => changeHoverState(false)}
+              >
+                {emojiList?.map(({ id, emoji }) => {
+                  return (
+                    <EmojiLabel
+                      key={id}
+                      isActive={id === myEmojiId}
+                      py="0.5rem"
+                      px="0.75rem"
+                      onClick={(e) => handleEmojiLabelClick(e, id)}
+                    >
+                      {emoji}
+                    </EmojiLabel>
+                  );
+                })}
+              </EmojiModal>
+            </EmojiButtonContainer>
 
-            if (!hasEmoji) return;
+            <EmojiLabelList>
+              {emojis.map(({ id, count }) => {
+                const hasEmoji = count > 0;
 
-            const emoji = emojiList?.find(({ id: emojiId }) => emojiId === id)?.emoji;
+                if (!hasEmoji) return;
 
-            return (
-              <EmojiLabelItem key={id}>
-                <EmojiLabel
-                  isActive={id === myEmojiId}
-                  py="0"
-                  px="0.75rem"
-                  onClick={(e) => handleEmojiLabelClick(e, id)}
-                >
-                  {`${emoji} ${count}`}
-                </EmojiLabel>
-              </EmojiLabelItem>
-            );
-          })}
-        </EmojiLabelList>
-      </Bottom>
+                const emoji = emojiList?.find(({ id: emojiId }) => emojiId === id)?.emoji;
+
+                return (
+                  <EmojiLabelItem key={id}>
+                    <EmojiLabel
+                      isActive={id === myEmojiId}
+                      py="0"
+                      px="0.75rem"
+                      onClick={(e) => handleEmojiLabelClick(e, id)}
+                    >
+                      {`${emoji} ${count}`}
+                    </EmojiLabel>
+                  </EmojiLabelItem>
+                );
+              })}
+            </EmojiLabelList>
+          </Bottom>
+        </>
+      )}
     </CommentLayout>
   );
 };

--- a/src/components/ReplyForm/ReplyAddForm/index.tsx
+++ b/src/components/ReplyForm/ReplyAddForm/index.tsx
@@ -1,0 +1,58 @@
+import React, { FormEvent, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, Textarea } from 'review-me-design-system';
+import { useUserContext } from '@contexts/userContext';
+import { usePostFeedbackReply } from '@apis/feedbackApi';
+import { usePostQuestionReply } from '@apis/questionApi';
+import { ReplyFormLayout } from '../style';
+
+interface Props {
+  type: 'feedback' | 'question';
+  resumeId: number;
+  parentId: number;
+}
+
+const ReplyAddForm = ({ type, resumeId, parentId }: Props) => {
+  const { jwt } = useUserContext();
+  const queryClient = useQueryClient();
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
+  const [content, setContent] = useState<string>('');
+  const { mutate: addFeedbackReply } = usePostFeedbackReply({ resumeId, parentId });
+  const { mutate: addQuestionReply } = usePostQuestionReply({ resumeId, parentId });
+
+  const resetForm = () => {
+    setContent('');
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!jwt) return;
+
+    const hasContent = content.trim().length > 0;
+
+    if (!hasContent) {
+      contentRef.current?.focus();
+      return;
+    }
+
+    if (type === 'feedback')
+      addFeedbackReply({ resumeId, parentFeedbackId: parentId, content: content.trim(), jwt });
+    else if (type === 'question')
+      addQuestionReply({ resumeId, parentQuestionId: parentId, content: content.trim(), jwt });
+
+    resetForm();
+  };
+
+  return (
+    <ReplyFormLayout onSubmit={handleSubmit}>
+      <Textarea ref={contentRef} value={content} onChange={(e) => setContent(e.target.value)} />
+      <Button variant="default" size="s">
+        작성
+      </Button>
+    </ReplyFormLayout>
+  );
+};
+
+export default ReplyAddForm;

--- a/src/components/ReplyForm/ReplyEditForm/index.tsx
+++ b/src/components/ReplyForm/ReplyEditForm/index.tsx
@@ -1,0 +1,89 @@
+import React, { FormEvent, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, Textarea } from 'review-me-design-system';
+import { useUserContext } from '@contexts/userContext';
+import { usePatchFeedback } from '@apis/feedbackApi';
+import { usePatchQuestion } from '@apis/questionApi';
+import { ButtonsContainer, ReplyFormLayout } from '../style';
+
+interface Props {
+  type: 'feedback' | 'question';
+  resumeId: number;
+  parentId: number;
+  id: number;
+  onCancelEdit: () => void;
+}
+
+const ReplyEditForm = ({ type, resumeId, parentId, id, onCancelEdit }: Props) => {
+  const { jwt } = useUserContext();
+  const queryClient = useQueryClient();
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
+  const [content, setContent] = useState<string>('');
+  const { mutate: editFeedbackReply } = usePatchFeedback();
+  const { mutate: editQuestionReply } = usePatchQuestion();
+
+  const resetForm = () => {
+    setContent('');
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!jwt) return;
+
+    const hasContent = content.trim().length > 0;
+
+    if (!hasContent) {
+      contentRef.current?.focus();
+      return;
+    }
+
+    if (type === 'feedback') {
+      editFeedbackReply(
+        { resumeId, feedbackId: id, content: content.trim(), jwt },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['feedbackReplyList', resumeId, parentId] });
+            resetForm();
+            onCancelEdit();
+          },
+        },
+      );
+    } else if (type === 'question') {
+      editQuestionReply(
+        { resumeId, questionId: id, content: content.trim(), jwt },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['questionReplyList', resumeId, parentId] });
+            resetForm();
+            onCancelEdit();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <ReplyFormLayout onSubmit={handleSubmit}>
+      <Textarea ref={contentRef} value={content} onChange={(e) => setContent(e.target.value)} />
+      <ButtonsContainer>
+        <Button
+          variant="outline"
+          size="s"
+          onClick={(e) => {
+            e.preventDefault();
+            onCancelEdit();
+          }}
+        >
+          취소
+        </Button>
+        <Button variant="default" size="s">
+          수정
+        </Button>
+      </ButtonsContainer>
+    </ReplyFormLayout>
+  );
+};
+
+export default ReplyEditForm;

--- a/src/components/ReplyForm/style.ts
+++ b/src/components/ReplyForm/style.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const ReplyFormLayout = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+  gap: 0.5rem;
+
+  & > button {
+    flex-shrink: 0;
+  }
+`;
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  width: 100%;
+`;
+
+export { ReplyFormLayout, ButtonsContainer };

--- a/src/components/ReplyList/index.tsx
+++ b/src/components/ReplyList/index.tsx
@@ -1,11 +1,11 @@
-import React, { FormEvent, useState } from 'react';
-import { Button, Textarea } from 'review-me-design-system';
+import React from 'react';
 import Reply, { ReplyType } from '@components/Comment/Reply';
+import ReplyAddForm from '@components/ReplyForm/ReplyAddForm';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import { useUserContext } from '@contexts/userContext';
-import { useFeedbackReplyList, usePostFeedbackReply } from '@apis/feedbackApi';
-import { usePostQuestionReply, useQuestionReplyList } from '@apis/questionApi';
-import { ReplyForm, ReplyListLayout } from './style';
+import { useFeedbackReplyList } from '@apis/feedbackApi';
+import { useQuestionReplyList } from '@apis/questionApi';
+import { ReplyListLayout } from './style';
 
 interface Props {
   type: 'feedback' | 'question';
@@ -38,10 +38,6 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
     },
   });
 
-  const [content, setContent] = useState<string>('');
-  const { mutate: addFeedbackReply } = usePostFeedbackReply({ resumeId, parentId });
-  const { mutate: addQuestionReply } = usePostQuestionReply({ resumeId, parentId });
-
   let replies: ReplyType[] = [];
 
   if (type === 'feedback' && feedbackReplyList)
@@ -55,22 +51,6 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
       .flat()
       .map((reply) => ({ ...reply, parentId: reply.parentQuestionId }));
 
-  const resetForm = () => {
-    setContent('');
-  };
-
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    if (!jwt) return;
-    if (content.length === 0) return;
-
-    if (type === 'feedback') addFeedbackReply({ resumeId, parentFeedbackId: parentId, content, jwt });
-    else if (type === 'question') addQuestionReply({ resumeId, parentQuestionId: parentId, content, jwt });
-
-    resetForm();
-  };
-
   return (
     <ReplyListLayout>
       <ul>
@@ -81,12 +61,7 @@ const ReplyList = ({ type, parentId, resumeId }: Props) => {
         ))}
         <div ref={setTarget}></div>
       </ul>
-      <ReplyForm onSubmit={handleSubmit}>
-        <Textarea value={content} onChange={(e) => setContent(e.target.value)} />
-        <Button variant="default" size="s">
-          작성
-        </Button>
-      </ReplyForm>
+      <ReplyAddForm type={type} resumeId={resumeId} parentId={parentId} />
     </ReplyListLayout>
   );
 };

--- a/src/components/ReplyList/style.ts
+++ b/src/components/ReplyList/style.ts
@@ -1,18 +1,6 @@
 import { theme } from 'review-me-design-system';
 import styled from 'styled-components';
 
-const ReplyForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: flex-end;
-  gap: 0.5rem;
-
-  & > button {
-    flex-shrink: 0;
-  }
-`;
-
 const ReplyListLayout = styled.div`
   display: flex;
   flex-direction: column;
@@ -21,4 +9,4 @@ const ReplyListLayout = styled.div`
   background-color: ${theme.palette.green100};
 `;
 
-export { ReplyForm, ReplyListLayout };
+export { ReplyListLayout };


### PR DESCRIPTION
## 개요

피드백 대댓글과 예상질문 대댓글 수정 기능

## 작업 사항

- 대댓글 form인 `ReplyAddForm` 컴포넌트 생성
- 대댓글을 수정하는 `ReplyEditForm` 컴포넌트 생성
- 대댓글 Dropdown의 `수정` 버튼을 누르면, `ReplyEditForm`이 표시된다.

`ReplyEditForm`
- 취소 버튼을 클릭시, form이 닫힌다.
- content를 입력한 상태에서 수정을 클릭하면, 서버에 수정 요청을 보내고 피드백 대댓글 목록을 다시 불러온다.
  - content에 값을 입력하지 않으면 focus한다. (=필수값이다.)

## 이슈 번호

close #132 