### PR TITLE
[FE] 예상질문 추가 / 수정 API 로직 수정

### DIFF
--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -168,14 +168,14 @@ export const postQuestion = async ({
 }: {
   resumeId: number;
   content: string;
-  labelContent: string;
+  labelContent: string | null;
   resumePage: number;
   jwt: string;
 }) => {
   const newQuestion: {
     content: string;
     resumePage: number;
-    labelContent: string;
+    labelContent: string | null;
   } = {
     content,
     resumePage,
@@ -244,8 +244,8 @@ export const patchQuestion = async ({
 }: {
   resumeId: number;
   questionId: number;
-  labelContent: string | null;
-  content: string | null;
+  labelContent?: string | null;
+  content: string;
   jwt: string;
 }) => {
   const requestBody: { labelContent?: string; content?: string } = {};

--- a/src/components/QuestionForm/QuestionAddForm/index.tsx
+++ b/src/components/QuestionForm/QuestionAddForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState } from 'react';
+import React, { FormEvent, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Input, Textarea } from 'review-me-design-system';
 import { useUserContext } from '@contexts/userContext';
@@ -14,6 +14,8 @@ const QuestionAddForm = ({ resumeId, resumePage }: Props) => {
   const queryClient = useQueryClient();
   const { jwt } = useUserContext();
 
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
   const [labelContent, setLabelContent] = useState<string>('');
   const [content, setContent] = useState<string>('');
 
@@ -27,7 +29,14 @@ const QuestionAddForm = ({ resumeId, resumePage }: Props) => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!jwt || !resumeId || !content) return;
+    if (!jwt || !resumeId) return;
+
+    const hasContent = content.trim().length > 0;
+
+    if (!hasContent) {
+      contentRef.current?.focus();
+      return;
+    }
 
     const hasLabelContent = labelContent.trim().length > 0;
 
@@ -59,7 +68,12 @@ const QuestionAddForm = ({ resumeId, resumePage }: Props) => {
         value={labelContent}
         onChange={(e) => setLabelContent(e.target.value)}
       />
-      <Textarea placeholder="예상질문" value={content} onChange={(e) => setContent(e.target.value)} />
+      <Textarea
+        ref={contentRef}
+        placeholder="예상질문"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
       <ButtonWrapper $type="add">
         <Button variant="default" size="s">
           작성

--- a/src/components/QuestionForm/QuestionAddForm/index.tsx
+++ b/src/components/QuestionForm/QuestionAddForm/index.tsx
@@ -29,11 +29,13 @@ const QuestionAddForm = ({ resumeId, resumePage }: Props) => {
 
     if (!jwt || !resumeId || !content) return;
 
+    const hasLabelContent = labelContent.trim().length > 0;
+
     addQuestion(
       {
         resumeId,
         content,
-        labelContent: labelContent.trim(),
+        labelContent: hasLabelContent ? labelContent.trim() : null,
         resumePage,
         jwt,
       },


### PR DESCRIPTION
## 개요

예상질문 추가 요청 보내는 함수와 수저 요청 보내는 함수의 매개변수 타입을 수정했다.

## 작업 사항

- 예상질문 추가할 때 labelContent에 아무런 값을 입력하지 않으면 null 값으로 보내도록 수정
- 예상질문 추가할 때 content에 아무런 내용을 입력하지 않으면 focus한다.
- 예상질문 수정 요청보내는 함수의 매개변수인 labelContent 타입 수정
  - 예상질문 대댓글에서 수정 요청 보낼 때 labelContent가 없으므로 undefined 타입 허용

## 이슈 번호

close #131 