### PR TITLE
[FE] 친구 검색 기능 구현

### DIFF
--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -18,12 +18,15 @@ export const getFriendList = async ({
   pageParam,
   jwt,
   size,
+  start,
 }: {
   pageParam: number;
   jwt?: string;
   size: number;
+  start?: string;
 }) => {
-  const response = await fetch(`${REQUEST_URL.FRIEND}?page=${pageParam}&size=${size || 10}`, {
+  const queryString = `page=${pageParam}&size=${size || 10}${start && `&start=${start}`}`;
+  const response = await fetch(`${REQUEST_URL.FRIEND}?${queryString}`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${jwt}`,
@@ -42,13 +45,14 @@ export const getFriendList = async ({
 interface UseFriendListProps {
   jwt?: string;
   size?: number;
+  start?: string;
 }
 
-export const useFriendList = ({ jwt, size = 10 }: UseFriendListProps) => {
+export const useFriendList = ({ jwt, size = 7, start }: UseFriendListProps) => {
   return useInfiniteQuery({
-    queryKey: ['friendList'],
+    queryKey: ['friendList', start],
     initialPageParam: 0,
-    queryFn: ({ pageParam }) => getFriendList({ pageParam, jwt, size }),
+    queryFn: ({ pageParam }) => getFriendList({ pageParam, jwt, size, start }),
     getNextPageParam: (lastPage) => {
       const { pageNumber, lastPage: lastPageNum } = lastPage;
 

--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -46,9 +46,10 @@ interface UseFriendListProps {
   jwt?: string;
   size?: number;
   start?: string;
+  enabled?: boolean;
 }
 
-export const useFriendList = ({ jwt, size = 7, start }: UseFriendListProps) => {
+export const useFriendList = ({ jwt, size = 7, start, enabled = true }: UseFriendListProps) => {
   return useInfiniteQuery({
     queryKey: ['friendList', start],
     initialPageParam: 0,
@@ -58,5 +59,6 @@ export const useFriendList = ({ jwt, size = 7, start }: UseFriendListProps) => {
 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
+    enabled,
   });
 };

--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 
@@ -60,5 +60,34 @@ export const useFriendList = ({ jwt, size = 7, start, enabled = true }: UseFrien
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
     enabled,
+  });
+};
+
+// DELETE 친구 삭제
+export const deleteFriend = async ({ friendId, jwt }: { friendId: number; jwt: string }) => {
+  const response = await fetch(`${REQUEST_URL.FRIEND}/${friendId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const useDeleteFriend = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteFriend,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['friendList'] });
+    },
   });
 };

--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -1,0 +1,58 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { REQUEST_URL } from '@constants';
+import { ApiResponse, PageNationData } from './response.types';
+
+// GET 친구 목록 조회
+export interface User {
+  id: number;
+  name: string;
+  profileUrl: string;
+}
+
+interface GetFriendList extends PageNationData {
+  users: User[];
+}
+
+// todo: jwt 타입을 string으로만 설정하는 법 찾아보기
+export const getFriendList = async ({
+  pageParam,
+  jwt,
+  size,
+}: {
+  pageParam: number;
+  jwt?: string;
+  size: number;
+}) => {
+  const response = await fetch(`${REQUEST_URL.FRIEND}?page=${pageParam}&size=${size || 10}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetFriendList> = await response.json();
+
+  return data;
+};
+
+interface UseFriendListProps {
+  jwt?: string;
+  size?: number;
+}
+
+export const useFriendList = ({ jwt, size = 10 }: UseFriendListProps) => {
+  return useInfiniteQuery({
+    queryKey: ['friendList'],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getFriendList({ pageParam, jwt, size }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+  });
+};

--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -49,7 +49,7 @@ interface UseFriendListProps {
   enabled?: boolean;
 }
 
-export const useFriendList = ({ jwt, size = 7, start, enabled = true }: UseFriendListProps) => {
+export const useFriendList = ({ jwt, size = 7, start = '', enabled = true }: UseFriendListProps) => {
   return useInfiniteQuery({
     queryKey: ['friendList', start],
     initialPageParam: 0,

--- a/src/components/FriendItem/index.tsx
+++ b/src/components/FriendItem/index.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
-import { Button } from 'review-me-design-system';
+import { Button, useModal } from 'review-me-design-system';
+import FriendDeleteModal from '@components/Modal/FriendDeleteModal';
+import { manageBodyScroll } from '@utils';
 import { ButtonsContainer, FriendItemLayout, UserImg, UserInfo, UserName } from './style';
 
 interface Props {
   type: 'friend' | 'request' | 'response';
+  userId: number;
   userImg: string;
   userName: string;
 }
 
-const FriendItem = ({ type, userImg, userName }: Props) => {
+const FriendItem = ({ type, userId, userImg, userName }: Props) => {
+  const {
+    isOpen: isFriendDeleteModalOpen,
+    open: openFriendDeleteModal,
+    close: closeFriendDeleteModal,
+  } = useModal();
+
   return (
     <FriendItemLayout>
       <UserInfo>
@@ -17,9 +26,26 @@ const FriendItem = ({ type, userImg, userName }: Props) => {
       </UserInfo>
 
       {type === 'friend' && (
-        <Button variant="outline" size="s">
-          삭제
-        </Button>
+        <>
+          <Button
+            variant="outline"
+            size="s"
+            onClick={() => {
+              openFriendDeleteModal();
+              manageBodyScroll(false);
+            }}
+          >
+            삭제
+          </Button>
+          <FriendDeleteModal
+            friendId={userId}
+            isOpen={isFriendDeleteModalOpen}
+            onClose={() => {
+              closeFriendDeleteModal();
+              manageBodyScroll(true);
+            }}
+          />
+        </>
       )}
       {type === 'request' && (
         <Button variant="outline" size="s">

--- a/src/components/FriendItem/style.ts
+++ b/src/components/FriendItem/style.ts
@@ -4,10 +4,11 @@ import { ellipsisStyles } from '@styles/common';
 
 const FriendItemLayout = styled.li`
   display: flex;
-  padding: 0.75rem 0rem;
   justify-content: space-between;
   align-items: center;
   gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 0rem;
 `;
 
 const UserInfo = styled.div`
@@ -41,4 +42,20 @@ const ButtonsContainer = styled.div`
   margin-left: 0.25rem;
 `;
 
-export { FriendItemLayout, UserInfo, UserImg, UserName, ButtonsContainer };
+// skeleton 스타일
+const SkeletonImg = styled.div`
+  width: 2.5rem;
+  height: 2.5rem;
+
+  border-radius: 50%;
+  background-color: ${theme.color.neutral.bg.light};
+`;
+
+const SkeletonUserName = styled.div`
+  width: 50%;
+  height: 1.75rem;
+
+  background-color: ${theme.color.neutral.bg.light};
+`;
+
+export { FriendItemLayout, UserInfo, UserImg, UserName, ButtonsContainer, SkeletonImg, SkeletonUserName };

--- a/src/components/Modal/FriendDeleteModal/index.tsx
+++ b/src/components/Modal/FriendDeleteModal/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Button, Modal } from 'review-me-design-system';
+import { useUserContext } from '@contexts/userContext';
+import { useDeleteFriend } from '@apis/friendApi';
+import { ButtonsContainer, Description } from './style';
+
+interface Props {
+  friendId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const FriendDeleteModal = ({ friendId, isOpen, onClose }: Props) => {
+  const { jwt } = useUserContext();
+  const { mutate: deleteFriend } = useDeleteFriend();
+
+  return (
+    <Modal modalRootId="modal-root" isOpen={isOpen} onClose={onClose} width="18.75rem">
+      <Description>
+        <Modal.Title>정말로 친구를 삭제하시겠습니까?</Modal.Title>
+        <Modal.Description>선택한 친구가 삭제됩니다.</Modal.Description>
+      </Description>
+      <ButtonsContainer>
+        <Button variant="outline" size="m" width="100%" onClick={onClose}>
+          취소
+        </Button>
+        <Button
+          variant="default"
+          size="m"
+          width="100%"
+          onClick={() => {
+            if (jwt) deleteFriend({ friendId, jwt });
+            onClose();
+          }}
+        >
+          삭제
+        </Button>
+      </ButtonsContainer>
+    </Modal>
+  );
+};
+
+export default FriendDeleteModal;

--- a/src/components/Modal/FriendDeleteModal/style.ts
+++ b/src/components/Modal/FriendDeleteModal/style.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const Description = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+`;
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  width: 80%;
+`;
+
+export { Description, ButtonsContainer };

--- a/src/components/Modal/FriendSearchModal/index.tsx
+++ b/src/components/Modal/FriendSearchModal/index.tsx
@@ -57,7 +57,13 @@ const FriendSearchModal = ({ isOpen, onClose }: Props) => {
       {name.length > 0 ? (
         <FriendList>
           {friendList?.map((friend) => (
-            <FriendItem key={friend.id} type="friend" userImg={friend.profileUrl} userName={friend.name} />
+            <FriendItem
+              key={friend.id}
+              type="friend"
+              userId={friend.id}
+              userImg={friend.profileUrl}
+              userName={friend.name}
+            />
           ))}
         </FriendList>
       ) : (

--- a/src/components/Modal/FriendSearchModal/index.tsx
+++ b/src/components/Modal/FriendSearchModal/index.tsx
@@ -54,9 +54,10 @@ const FriendSearchModal = ({ isOpen, onClose }: Props) => {
         }}
       />
 
-      {name.length > 0 ? (
+      {name.length === 0 && <SearchUserInstruction>친구의 이름을 검색해주세요.</SearchUserInstruction>}
+      {name.length > 0 && friendList && friendList.length > 0 && (
         <FriendList>
-          {friendList?.map((friend) => (
+          {friendList.map((friend) => (
             <FriendItem
               key={friend.id}
               type="friend"
@@ -66,8 +67,9 @@ const FriendSearchModal = ({ isOpen, onClose }: Props) => {
             />
           ))}
         </FriendList>
-      ) : (
-        <SearchUserInstruction>친구의 이름을 검색해주세요.</SearchUserInstruction>
+      )}
+      {name.length > 0 && friendList && friendList.length === 0 && (
+        <SearchUserInstruction>검색어와 일치하는 친구가 없습니다.</SearchUserInstruction>
       )}
     </Modal>
   );

--- a/src/components/Modal/FriendSearchModal/index.tsx
+++ b/src/components/Modal/FriendSearchModal/index.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { Icon, Input, Modal } from 'review-me-design-system';
+import FriendItem from '@components/FriendItem';
+import useMediaQuery from '@hooks/useMediaQuery';
+import { useUserContext } from '@contexts/userContext';
+import { useFriendList } from '@apis/friendApi';
+import { FriendList, Header, IconButton, SearchUserInstruction } from './style';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const FriendSearchModal = ({ isOpen, onClose }: Props) => {
+  const { jwt } = useUserContext();
+  const { matches: isMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 768px)' });
+
+  const [name, setName] = useState<string>('');
+
+  const { data: friendListData } = useFriendList({ jwt, start: name, enabled: !!name });
+
+  const friendList = friendListData?.pages.map((page) => page.users).flat();
+
+  return (
+    <Modal
+      modalRootId="modal-root"
+      isOpen={isOpen}
+      onClose={() => {
+        onClose();
+      }}
+      width={isMDevice ? '80%' : '37.5rem'}
+    >
+      <Header>
+        <Modal.Title>친구</Modal.Title>
+        <IconButton onClick={onClose}>
+          <Icon iconName="xMark" />
+        </IconButton>
+      </Header>
+
+      <Input
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+      />
+
+      {name.length > 0 ? (
+        <FriendList>
+          {friendList?.map((friend) => (
+            <FriendItem key={friend.id} type="friend" userImg={friend.profileUrl} userName={friend.name} />
+          ))}
+        </FriendList>
+      ) : (
+        <SearchUserInstruction>친구의 이름을 검색해주세요.</SearchUserInstruction>
+      )}
+    </Modal>
+  );
+};
+
+export default FriendSearchModal;

--- a/src/components/Modal/FriendSearchModal/index.tsx
+++ b/src/components/Modal/FriendSearchModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Icon, Input, Modal } from 'review-me-design-system';
 import FriendItem from '@components/FriendItem';
 import useMediaQuery from '@hooks/useMediaQuery';
@@ -17,9 +17,19 @@ const FriendSearchModal = ({ isOpen, onClose }: Props) => {
 
   const [name, setName] = useState<string>('');
 
-  const { data: friendListData } = useFriendList({ jwt, start: name, enabled: !!name });
+  const { data: friendListData, refetch } = useFriendList({ jwt, start: name, enabled: false });
 
   const friendList = friendListData?.pages.map((page) => page.users).flat();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      refetch();
+    }, 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [name]);
 
   return (
     <Modal

--- a/src/components/Modal/FriendSearchModal/style.ts
+++ b/src/components/Modal/FriendSearchModal/style.ts
@@ -1,0 +1,27 @@
+import { theme } from 'review-me-design-system';
+import styled from 'styled-components';
+
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const IconButton = styled.button`
+  background-color: transparent;
+
+  cursor: pointer;
+`;
+
+const FriendList = styled.ul`
+  width: 100%;
+  max-height: 28.875rem;
+  overflow-y: auto;
+`;
+
+const SearchUserInstruction = styled.span`
+  ${theme.font.body.medium}
+  color: ${theme.color.neutral.text.sub}
+`;
+
+export { Header, IconButton, FriendList, SearchUserInstruction };

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Button, Icon } from 'review-me-design-system';
+import { Button, Icon, useModal } from 'review-me-design-system';
 import { css } from 'styled-components';
 import FriendItem from '@components/FriendItem';
+import FriendSearchModal from '@components/Modal/FriendSearchModal';
 import { useUserContext } from '@contexts/userContext';
 import { useFriendList } from '@apis/friendApi';
 import { PageMain } from '@styles/common';
+import { manageBodyScroll } from '@utils';
 import {
   FriendSectionContainer,
   FriendSection,
@@ -22,6 +24,12 @@ const MyPage = () => {
   const { data: friendListData } = useFriendList({ jwt, size: SIZE });
 
   const friendList = friendListData?.pages.map((page) => page.users).flat();
+
+  const {
+    isOpen: isFriendSearchModalOpen,
+    open: openFriendSearchModal,
+    close: closeFriendSearchModal,
+  } = useModal();
 
   return (
     <PageMain
@@ -42,9 +50,21 @@ const MyPage = () => {
         <FriendSection>
           <Title>
             <span>내 친구</span>
-            <OpenModalButton>
+            <OpenModalButton
+              onClick={() => {
+                openFriendSearchModal();
+                manageBodyScroll(false);
+              }}
+            >
               <Icon iconName="rightArrow" />
             </OpenModalButton>
+            <FriendSearchModal
+              isOpen={isFriendSearchModalOpen}
+              onClose={() => {
+                closeFriendSearchModal();
+                manageBodyScroll(true);
+              }}
+            />
           </Title>
 
           <ul>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -3,6 +3,7 @@ import { Button, Icon } from 'review-me-design-system';
 import { css } from 'styled-components';
 import FriendItem from '@components/FriendItem';
 import { useUserContext } from '@contexts/userContext';
+import { useFriendList } from '@apis/friendApi';
 import { PageMain } from '@styles/common';
 import {
   FriendSectionContainer,
@@ -15,7 +16,12 @@ import {
 } from './style';
 
 const MyPage = () => {
-  const { user } = useUserContext();
+  const SIZE = 2;
+  const { user, jwt } = useUserContext();
+
+  const { data: friendListData } = useFriendList({ jwt, size: SIZE });
+
+  const friendList = friendListData?.pages.map((page) => page.users).flat();
 
   return (
     <PageMain
@@ -42,8 +48,9 @@ const MyPage = () => {
           </Title>
 
           <ul>
-            <FriendItem type="friend" userImg="" userName="김가나" />
-            <FriendItem type="friend" userImg="" userName="김가나" />
+            {friendList?.map((friend) => (
+              <FriendItem type="friend" key={friend.id} userName={friend.name} userImg={friend.profileUrl} />
+            ))}
           </ul>
         </FriendSection>
 

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -19,7 +19,7 @@ const MyPage = () => {
 
   return (
     <PageMain
-      css={css`
+      $css={css`
         align-items: center;
       `}
     >

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -8,7 +8,7 @@ import { PageMain } from '@styles/common';
 import {
   FriendSectionContainer,
   FriendSection,
-  NavigationButton,
+  OpenModalButton,
   Title,
   UserImg,
   UserInfo,
@@ -42,9 +42,9 @@ const MyPage = () => {
         <FriendSection>
           <Title>
             <span>내 친구</span>
-            <NavigationButton>
+            <OpenModalButton>
               <Icon iconName="rightArrow" />
-            </NavigationButton>
+            </OpenModalButton>
           </Title>
 
           <ul>
@@ -57,9 +57,9 @@ const MyPage = () => {
         <FriendSection>
           <Title>
             <span>내가 친구 요청 보낸 사람</span>
-            <NavigationButton>
+            <OpenModalButton>
               <Icon iconName="rightArrow" />
-            </NavigationButton>
+            </OpenModalButton>
           </Title>
 
           <ul>
@@ -71,9 +71,9 @@ const MyPage = () => {
         <FriendSection>
           <Title>
             <span>나에게 친구 요청 보낸 사람</span>
-            <NavigationButton>
+            <OpenModalButton>
               <Icon iconName="rightArrow" />
-            </NavigationButton>
+            </OpenModalButton>
           </Title>
 
           <ul>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -69,7 +69,13 @@ const MyPage = () => {
 
           <ul>
             {friendList?.map((friend) => (
-              <FriendItem type="friend" key={friend.id} userName={friend.name} userImg={friend.profileUrl} />
+              <FriendItem
+                type="friend"
+                key={friend.id}
+                userId={friend.id}
+                userName={friend.name}
+                userImg={friend.profileUrl}
+              />
             ))}
           </ul>
         </FriendSection>
@@ -83,8 +89,8 @@ const MyPage = () => {
           </Title>
 
           <ul>
-            <FriendItem type="request" userImg="" userName="김가나" />
-            <FriendItem type="request" userImg="" userName="김가나" />
+            <FriendItem type="request" userId={1} userImg="" userName="김가나" />
+            <FriendItem type="request" userId={2} userImg="" userName="김가나" />
           </ul>
         </FriendSection>
 
@@ -97,8 +103,8 @@ const MyPage = () => {
           </Title>
 
           <ul>
-            <FriendItem type="response" userImg="" userName="김가나" />
-            <FriendItem type="response" userImg="" userName="김가나" />
+            <FriendItem type="response" userId={3} userImg="" userName="김가나" />
+            <FriendItem type="response" userId={4} userImg="" userName="김가나" />
           </ul>
         </FriendSection>
       </FriendSectionContainer>

--- a/src/pages/MyPage/style.ts
+++ b/src/pages/MyPage/style.ts
@@ -55,10 +55,10 @@ const Title = styled.header`
   color: ${theme.color.neutral.text.strong};
 `;
 
-const NavigationButton = styled.button`
+const OpenModalButton = styled.button`
   background-color: transparent;
 
   cursor: pointer;
 `;
 
-export { UserInfo, UserImg, UserName, FriendSectionContainer, FriendSection, Title, NavigationButton };
+export { UserInfo, UserImg, UserName, FriendSectionContainer, FriendSection, Title, OpenModalButton };

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -8,7 +8,7 @@ export const ellipsisStyles = css`
   word-break: break-all;
 `;
 
-export const PageMain = styled.main<{ css?: CSSProp }>`
+export const PageMain = styled.main<{ $css?: CSSProp }>`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -24,5 +24,5 @@ export const PageMain = styled.main<{ css?: CSSProp }>`
     margin: 0.5rem auto;
   }
 
-  ${({ css }) => css}
+  ${({ $css }) => $css}
 `;


### PR DESCRIPTION
## 개요

마이 페이지에서 친구 옆의 `>`를 클릭할 경우 친구 목록을 검색할 수 있는 Modal 창이 뜬다.

## 작업 사항

마이페이지에서 
- 2명의 친구 항목을 보여준다.
- 친구 옆에 `>` 버튼을 누르면 친구를 검색할 수 있는 Modal 창이 뜬다.

친구 목록 Modal
- 입력한 문자열로 시작하는 이름을 가진 사용자를 검색할 수 있다.
- 검색창에 입력한 값에 해당하는 사용자들의 목록이 보인다.
- 검색창에 값을 입력하지 않았을 경우, 전체 친구들이 보인다.
- `x` 버튼을 클릭할 경우, Modal 창이 닫힌다.
- `삭제` 버튼을 클릭할 경우, 정말로 친구를 삭제할 것인지 확인하는 Modal이 화면에 보인다.
  - Modal에서 `취소` 버튼을 클릭할 경우, Modal이 닫힌다.
  - Modal에서 `삭제` 버튼을 클릭할 경우, 해당 친구가 삭제되면서 Modal이 닫힌다.

## 이슈 번호

close #137 
