### PR TITLE
[FE] 전송한 친구 요청 보기 기능

### DIFF
--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -118,6 +118,61 @@ export const usePostFriendRequest = () => {
   });
 };
 
+// GET 내가 보낸 친구 요청 목록 조회
+interface GetFollowingList extends PageNationData {
+  users: User[];
+}
+const getFollowingList = async ({
+  pageParam,
+  start,
+  size,
+  jwt,
+}: {
+  pageParam: number;
+  start: string;
+  size: number;
+  jwt?: string;
+}) => {
+  const response = await fetch(
+    `${REQUEST_URL.FRIEND}/following?page=${pageParam}&size=${size}${start && `&start=${start}`}`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetFollowingList> = await response.json();
+
+  return data;
+};
+
+interface UseFollowingListProps {
+  jwt?: string;
+  start?: string;
+  size?: number;
+  enabled?: boolean;
+}
+
+export const useFollowingList = ({ jwt, start = '', size = 7, enabled = true }: UseFollowingListProps) => {
+  return useInfiniteQuery({
+    queryKey: ['followingList', start],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getFollowingList({ pageParam, start, size, jwt }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+    enabled,
+  });
+};
+
 // DELETE 친구 요청 취소
 const deleteFriendRequest = async ({ userId, jwt }: { userId: number; jwt: string }) => {
   const response = await fetch(`${REQUEST_URL.FRIEND}/following/${userId}`, {

--- a/src/components/Modal/FollowingModal/index.tsx
+++ b/src/components/Modal/FollowingModal/index.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+import { Icon, Input, Modal } from 'review-me-design-system';
+import FriendItem from '@components/FriendItem';
+import useIntersectionObserver from '@hooks/useIntersectionObserver';
+import useMediaQuery from '@hooks/useMediaQuery';
+import { useUserContext } from '@contexts/userContext';
+import { useFollowingList } from '@apis/friendApi';
+import { Header, IconButton, SearchUserInstruction, UserList } from './style';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const FollowingModal = ({ isOpen, onClose }: Props) => {
+  const SIZE = 7;
+  const { jwt } = useUserContext();
+  const { matches: isMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 768px)' });
+
+  const [name, setName] = useState<string>('');
+
+  const {
+    data: followingListData,
+    refetch,
+    fetchNextPage,
+  } = useFollowingList({ jwt, start: name, size: SIZE, enabled: name.length === 0 });
+  const { setTarget } = useIntersectionObserver({
+    onIntersect: () => {
+      fetchNextPage();
+    },
+    options: { threshold: 0.5 },
+  });
+
+  const followingList = followingListData?.pages.map((page) => page.users).flat();
+
+  useEffect(() => {
+    if (name.length === 0) return;
+
+    const timer = setTimeout(() => {
+      refetch();
+    }, 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [name]);
+
+  return (
+    <Modal
+      modalRootId="modal-root"
+      isOpen={isOpen}
+      onClose={() => {
+        onClose();
+      }}
+      width={isMDevice ? '80%' : '37.5rem'}
+    >
+      <Header>
+        <Modal.Title>전송한 친구 요청 보기</Modal.Title>
+        <IconButton onClick={onClose}>
+          <Icon iconName="xMark" />
+        </IconButton>
+      </Header>
+
+      <Input
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+      />
+
+      {followingList && followingList.length > 0 && (
+        <UserList>
+          {followingList.map((user) => (
+            <FriendItem
+              key={user.id}
+              type="request"
+              userId={user.id}
+              userImg={user.profileUrl}
+              userName={user.name}
+            />
+          ))}
+          {followingList.length >= SIZE && <div ref={setTarget}></div>}
+        </UserList>
+      )}
+      {name.length > 0 && followingList && followingList.length === 0 && (
+        <SearchUserInstruction>검색어와 일치하는 친구가 없습니다.</SearchUserInstruction>
+      )}
+    </Modal>
+  );
+};
+
+export default FollowingModal;

--- a/src/components/Modal/FollowingModal/index.tsx
+++ b/src/components/Modal/FollowingModal/index.tsx
@@ -33,6 +33,11 @@ const FollowingModal = ({ isOpen, onClose }: Props) => {
 
   const followingList = followingListData?.pages.map((page) => page.users).flat();
 
+  const handleClose = () => {
+    onClose();
+    setName('');
+  };
+
   useEffect(() => {
     if (name.length === 0) return;
 
@@ -49,14 +54,12 @@ const FollowingModal = ({ isOpen, onClose }: Props) => {
     <Modal
       modalRootId="modal-root"
       isOpen={isOpen}
-      onClose={() => {
-        onClose();
-      }}
+      onClose={handleClose}
       width={isMDevice ? '80%' : '37.5rem'}
     >
       <Header>
         <Modal.Title>전송한 친구 요청 보기</Modal.Title>
-        <IconButton onClick={onClose}>
+        <IconButton onClick={handleClose}>
           <Icon iconName="xMark" />
         </IconButton>
       </Header>

--- a/src/components/Modal/FollowingModal/style.ts
+++ b/src/components/Modal/FollowingModal/style.ts
@@ -1,0 +1,27 @@
+import { theme } from 'review-me-design-system';
+import styled from 'styled-components';
+
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const IconButton = styled.button`
+  background-color: transparent;
+
+  cursor: pointer;
+`;
+
+const UserList = styled.ul`
+  width: 100%;
+  max-height: 28.875rem;
+  overflow-y: auto;
+`;
+
+const SearchUserInstruction = styled.span`
+  ${theme.font.body.medium}
+  color: ${theme.color.neutral.text.sub}
+`;
+
+export { Header, IconButton, UserList, SearchUserInstruction };

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Icon, useModal } from 'review-me-design-system';
 import { css } from 'styled-components';
 import FriendItem from '@components/FriendItem';
+import FollowingModal from '@components/Modal/FollowingModal';
 import FriendRequestModal from '@components/Modal/FriendRequestModal';
 import FriendSearchModal from '@components/Modal/FriendSearchModal';
 import { useUserContext } from '@contexts/userContext';
@@ -38,6 +39,7 @@ const MyPage = () => {
     open: openFriendSearchModal,
     close: closeFriendSearchModal,
   } = useModal();
+  const { isOpen: isFollowingModalOpen, open: openFollowingModal, close: closeFollowingModal } = useModal();
 
   return (
     <PageMain
@@ -105,9 +107,21 @@ const MyPage = () => {
         <FriendSection>
           <Title>
             <span>전송한 친구 요청 보기</span>
-            <OpenModalButton>
+            <OpenModalButton
+              onClick={() => {
+                openFollowingModal();
+                manageBodyScroll(false);
+              }}
+            >
               <Icon iconName="rightArrow" />
             </OpenModalButton>
+            <FollowingModal
+              isOpen={isFollowingModalOpen}
+              onClose={() => {
+                closeFollowingModal();
+                manageBodyScroll(true);
+              }}
+            />
           </Title>
 
           <ul>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -102,7 +102,7 @@ const MyPage = () => {
 
         <FriendSection>
           <Title>
-            <span>내가 친구 요청 보낸 사람</span>
+            <span>전송한 친구 요청 보기</span>
             <OpenModalButton>
               <Icon iconName="rightArrow" />
             </OpenModalButton>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -5,7 +5,7 @@ import FriendItem from '@components/FriendItem';
 import FriendRequestModal from '@components/Modal/FriendRequestModal';
 import FriendSearchModal from '@components/Modal/FriendSearchModal';
 import { useUserContext } from '@contexts/userContext';
-import { useFriendList } from '@apis/friendApi';
+import { useFollowingList, useFriendList } from '@apis/friendApi';
 import { PageMain } from '@styles/common';
 import { manageBodyScroll } from '@utils';
 import {
@@ -23,8 +23,10 @@ const MyPage = () => {
   const { user, jwt } = useUserContext();
 
   const { data: friendListData } = useFriendList({ jwt, size: SIZE });
+  const { data: followingListData } = useFollowingList({ jwt, size: SIZE });
 
   const friendList = friendListData?.pages.map((page) => page.users).flat();
+  const followingList = followingListData?.pages.map((page) => page.users).flat();
 
   const {
     isOpen: isFriendRequestModalOpen,
@@ -109,8 +111,15 @@ const MyPage = () => {
           </Title>
 
           <ul>
-            <FriendItem type="request" userId={1} userImg="" userName="김가나" />
-            <FriendItem type="request" userId={2} userImg="" userName="김가나" />
+            {followingList?.map((user) => (
+              <FriendItem
+                key={user.id}
+                type="request"
+                userId={user.id}
+                userName={user.name}
+                userImg={user.profileUrl}
+              />
+            ))}
           </ul>
         </FriendSection>
 

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -20,14 +20,21 @@ import {
 } from './style';
 
 const MyPage = () => {
-  const SIZE = 2;
+  const SIZE = 7;
   const { user, jwt } = useUserContext();
 
   const { data: friendListData } = useFriendList({ jwt, size: SIZE });
-  const { data: followingListData } = useFollowingList({ jwt, size: SIZE });
+  const { data: followingListData, refetch: refetchFollowingList } = useFollowingList({ jwt, size: SIZE });
 
-  const friendList = friendListData?.pages.map((page) => page.users).flat();
-  const followingList = followingListData?.pages.map((page) => page.users).flat();
+  const ITEM_COUNT = 2;
+  const friendList = friendListData?.pages
+    .map((page) => page.users)
+    .flat()
+    .slice(0, ITEM_COUNT);
+  const followingList = followingListData?.pages
+    .map((page) => page.users)
+    .flat()
+    .slice(0, ITEM_COUNT);
 
   const {
     isOpen: isFriendRequestModalOpen,
@@ -120,6 +127,7 @@ const MyPage = () => {
               onClose={() => {
                 closeFollowingModal();
                 manageBodyScroll(true);
+                refetchFollowingList();
               }}
             />
           </Title>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -74,6 +74,7 @@ const MyPage = () => {
         onClose={() => {
           closeFriendRequestModal();
           manageBodyScroll(true);
+          refetchFollowingList();
         }}
       />
 


### PR DESCRIPTION
## 개요

사용자가 친구 요청 보낸 사람들을 검색할 수 있는 기능을 구현했다.

## 작업 사항

마이 페이지
- 사용자가 친구 요청 보낸 사람 2명을 보여준다.
- 전송한 친구 요청 보기 옆에 > 버튼을 누르면 친구 목록이 있는 Modal 창이 뜬다.

전송한 친구 요청 보기 Modal

- 입력한 문자열로 시작하는 이름을 가진 사용자를 검색할 수 있다.
- 검색창에 입력한 값에 해당하는 사용자들의 목록이 보인다.
- 검색창에 값을 입력하지 않았을 경우, 전송한 친구 요청 목록이 보인다.
- `x` 버튼을 클릭할 경우, Modal 창이 닫힌다.
- `요청 취소`을 클릭할 경우, `친구 요청` 버튼으로 바뀐다.
    - `요청 취소` 버튼을 클릭했을 당시에는 `친구 요청` 버튼으로 바뀐다.
    - 다시 input에 김을 입력했을 경우에는, 내가 요청 보낸 사람은 목록에 포함되지 않는다.

## 이슈 번호

close #141 