### PR TITLE
[FE] 친구 요청에 응답하기 기능 구현

### DIFF
--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -242,3 +242,29 @@ export const useDeleteFriendRequest = () => {
     mutationFn: deleteFriendRequest,
   });
 };
+
+// PATCH 친구 요청 수락
+const patchFriendRequest = async ({ userId, jwt }: { userId: number; jwt: string }) => {
+  const response = await fetch(REQUEST_URL.FRIEND, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ userId }),
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const usePatchFriendRequest = () => {
+  return useMutation({
+    mutationFn: patchFriendRequest,
+  });
+};

--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -244,7 +244,7 @@ export const useDeleteFriendRequest = () => {
 };
 
 // PATCH 친구 요청 수락
-const patchFriendRequest = async ({ userId, jwt }: { userId: number; jwt: string }) => {
+const acceptFriendRequest = async ({ userId, jwt }: { userId: number; jwt: string }) => {
   const response = await fetch(REQUEST_URL.FRIEND, {
     method: 'PATCH',
     headers: {
@@ -263,8 +263,8 @@ const patchFriendRequest = async ({ userId, jwt }: { userId: number; jwt: string
   return data;
 };
 
-export const usePatchFriendRequest = () => {
+export const useAcceptFriendRequest = () => {
   return useMutation({
-    mutationFn: patchFriendRequest,
+    mutationFn: acceptFriendRequest,
   });
 };

--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -173,6 +173,52 @@ export const useFollowingList = ({ jwt, start = '', size = 7, enabled = true }: 
   });
 };
 
+// GET 나에게 온 친구 요청 목록 조회
+interface GetFollowerList extends PageNationData {
+  users: User[];
+}
+
+const getFollowerList = async ({
+  jwt,
+  pageParam,
+  start,
+}: {
+  jwt?: string;
+  pageParam: number;
+  start: string;
+}) => {
+  const response = await fetch(
+    `${REQUEST_URL.FRIEND}/follower?page=${pageParam}&size=7${start && `&start=${start}`}`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<GetFollowerList> = await response.json();
+
+  return data;
+};
+
+export const useFollowerList = ({ jwt, start = '' }: { jwt?: string; start?: string }) => {
+  return useInfiniteQuery({
+    queryKey: ['followerList'],
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) => getFollowerList({ jwt, pageParam, start }),
+    getNextPageParam: (lastPage) => {
+      const { pageNumber, lastPage: lastPageNum } = lastPage;
+
+      return pageNumber < lastPageNum ? pageNumber + 1 : null;
+    },
+  });
+};
+
 // DELETE 친구 요청 취소
 const deleteFriendRequest = async ({ userId, jwt }: { userId: number; jwt: string }) => {
   const response = await fetch(`${REQUEST_URL.FRIEND}/following/${userId}`, {

--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -264,8 +264,13 @@ const acceptFriendRequest = async ({ userId, jwt }: { userId: number; jwt: strin
 };
 
 export const useAcceptFriendRequest = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: acceptFriendRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['followerList'] });
+    },
   });
 };
 
@@ -288,7 +293,12 @@ const rejectFriendRequest = async ({ userId, jwt }: { userId: number; jwt: strin
 };
 
 export const useRejectFriendRequest = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: rejectFriendRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['followerList'] });
+    },
   });
 };

--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -268,3 +268,27 @@ export const useAcceptFriendRequest = () => {
     mutationFn: acceptFriendRequest,
   });
 };
+
+// PATCH 친구 요청 거절
+const rejectFriendRequest = async ({ userId, jwt }: { userId: number; jwt: string }) => {
+  const response = await fetch(`${REQUEST_URL.FRIEND}/${userId}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  const { data }: ApiResponse<null> = await response.json();
+
+  return data;
+};
+
+export const useRejectFriendRequest = () => {
+  return useMutation({
+    mutationFn: rejectFriendRequest,
+  });
+};

--- a/src/components/FriendItem/index.tsx
+++ b/src/components/FriendItem/index.tsx
@@ -95,7 +95,6 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
             size="s"
             onClick={() => {
               if (jwt) acceptFriendRequest({ userId, jwt });
-              setType('friend');
             }}
           >
             수락
@@ -105,7 +104,6 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
             size="s"
             onClick={() => {
               if (jwt) rejectFriendRequest({ userId, jwt });
-              setType('none');
             }}
           >
             거절

--- a/src/components/FriendItem/index.tsx
+++ b/src/components/FriendItem/index.tsx
@@ -2,7 +2,12 @@ import React, { useState } from 'react';
 import { Button, useModal } from 'review-me-design-system';
 import FriendDeleteModal from '@components/Modal/FriendDeleteModal';
 import { useUserContext } from '@contexts/userContext';
-import { useDeleteFriendRequest, useAcceptFriendRequest, usePostFriendRequest } from '@apis/friendApi';
+import {
+  useDeleteFriendRequest,
+  useAcceptFriendRequest,
+  usePostFriendRequest,
+  useRejectFriendRequest,
+} from '@apis/friendApi';
 import { manageBodyScroll } from '@utils';
 import { ButtonsContainer, FriendItemLayout, UserImg, UserInfo, UserName } from './style';
 
@@ -28,6 +33,7 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
   const { mutate: requestFriend } = usePostFriendRequest();
   const { mutate: cancelFriendRequest } = useDeleteFriendRequest();
   const { mutate: acceptFriendRequest } = useAcceptFriendRequest();
+  const { mutate: rejectFriendRequest } = useRejectFriendRequest();
 
   return (
     <FriendItemLayout>
@@ -94,7 +100,14 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
           >
             수락
           </Button>
-          <Button variant="outline" size="s">
+          <Button
+            variant="outline"
+            size="s"
+            onClick={() => {
+              if (jwt) rejectFriendRequest({ userId, jwt });
+              setType('none');
+            }}
+          >
             거절
           </Button>
         </ButtonsContainer>

--- a/src/components/FriendItem/index.tsx
+++ b/src/components/FriendItem/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, useModal } from 'review-me-design-system';
 import FriendDeleteModal from '@components/Modal/FriendDeleteModal';
 import { useUserContext } from '@contexts/userContext';
-import { useDeleteFriendRequest, usePatchFriendRequest, usePostFriendRequest } from '@apis/friendApi';
+import { useDeleteFriendRequest, useAcceptFriendRequest, usePostFriendRequest } from '@apis/friendApi';
 import { manageBodyScroll } from '@utils';
 import { ButtonsContainer, FriendItemLayout, UserImg, UserInfo, UserName } from './style';
 
@@ -27,7 +27,7 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
   } = useModal();
   const { mutate: requestFriend } = usePostFriendRequest();
   const { mutate: cancelFriendRequest } = useDeleteFriendRequest();
-  const { mutate: acceptFriendRequest } = usePatchFriendRequest();
+  const { mutate: acceptFriendRequest } = useAcceptFriendRequest();
 
   return (
     <FriendItemLayout>

--- a/src/components/FriendItem/index.tsx
+++ b/src/components/FriendItem/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, useModal } from 'review-me-design-system';
 import FriendDeleteModal from '@components/Modal/FriendDeleteModal';
 import { useUserContext } from '@contexts/userContext';
-import { useDeleteFriendRequest, usePostFriendRequest } from '@apis/friendApi';
+import { useDeleteFriendRequest, usePatchFriendRequest, usePostFriendRequest } from '@apis/friendApi';
 import { manageBodyScroll } from '@utils';
 import { ButtonsContainer, FriendItemLayout, UserImg, UserInfo, UserName } from './style';
 
@@ -27,6 +27,7 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
   } = useModal();
   const { mutate: requestFriend } = usePostFriendRequest();
   const { mutate: cancelFriendRequest } = useDeleteFriendRequest();
+  const { mutate: acceptFriendRequest } = usePatchFriendRequest();
 
   return (
     <FriendItemLayout>
@@ -83,7 +84,14 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
       )}
       {type === 'response' && (
         <ButtonsContainer>
-          <Button variant="default" size="s">
+          <Button
+            variant="default"
+            size="s"
+            onClick={() => {
+              if (jwt) acceptFriendRequest({ userId, jwt });
+              setType('friend');
+            }}
+          >
             수락
           </Button>
           <Button variant="outline" size="s">

--- a/src/components/Modal/FollowerModal/index.tsx
+++ b/src/components/Modal/FollowerModal/index.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { Icon, Input, Modal } from 'review-me-design-system';
+import FriendItem from '@components/FriendItem';
+import useIntersectionObserver from '@hooks/useIntersectionObserver';
+import useMediaQuery from '@hooks/useMediaQuery';
+import { useUserContext } from '@contexts/userContext';
+import { useFollowerList } from '@apis/friendApi';
+import { Header, IconButton, SearchUserInstruction, UserList } from './style';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const FollowerModal = ({ isOpen, onClose }: Props) => {
+  const SIZE = 7;
+  const { jwt } = useUserContext();
+  const { matches: isMDevice } = useMediaQuery({ mediaQueryString: '(max-width: 768px)' });
+
+  const [name, setName] = useState<string>('');
+
+  const { data: followerListData, refetch, fetchNextPage } = useFollowerList({ jwt, start: name });
+  const { setTarget } = useIntersectionObserver({
+    onIntersect: () => {
+      fetchNextPage();
+    },
+    options: { threshold: 0.5 },
+  });
+
+  const followerList = followerListData?.pages.map((page) => page.users).flat();
+
+  const handleClose = () => {
+    onClose();
+    setName('');
+  };
+
+  useEffect(() => {
+    if (name.length === 0) return;
+
+    const timer = setTimeout(() => {
+      refetch();
+    }, 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [name]);
+
+  return (
+    <Modal
+      modalRootId="modal-root"
+      isOpen={isOpen}
+      onClose={handleClose}
+      width={isMDevice ? '80%' : '37.5rem'}
+    >
+      <Header>
+        <Modal.Title>친구 요청에 응답하기</Modal.Title>
+        <IconButton onClick={handleClose}>
+          <Icon iconName="xMark" />
+        </IconButton>
+      </Header>
+
+      <Input
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+      />
+
+      {followerList && followerList.length > 0 && (
+        <UserList>
+          {followerList.map((user) => (
+            <FriendItem
+              key={user.id}
+              type="response"
+              userId={user.id}
+              userImg={user.profileUrl}
+              userName={user.name}
+            />
+          ))}
+          {followerList.length >= SIZE && <div ref={setTarget}></div>}
+        </UserList>
+      )}
+      {name.length > 0 && followerList && followerList.length === 0 && (
+        <SearchUserInstruction>검색어와 일치하는 사용자가 없습니다.</SearchUserInstruction>
+      )}
+    </Modal>
+  );
+};
+
+export default FollowerModal;

--- a/src/components/Modal/FollowerModal/style.ts
+++ b/src/components/Modal/FollowerModal/style.ts
@@ -1,0 +1,27 @@
+import { theme } from 'review-me-design-system';
+import styled from 'styled-components';
+
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const IconButton = styled.button`
+  background-color: transparent;
+
+  cursor: pointer;
+`;
+
+const UserList = styled.ul`
+  width: 100%;
+  max-height: 28.875rem;
+  overflow-y: auto;
+`;
+
+const SearchUserInstruction = styled.span`
+  ${theme.font.body.medium}
+  color: ${theme.color.neutral.text.sub}
+`;
+
+export { Header, IconButton, UserList, SearchUserInstruction };

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -6,7 +6,7 @@ import FollowingModal from '@components/Modal/FollowingModal';
 import FriendRequestModal from '@components/Modal/FriendRequestModal';
 import FriendSearchModal from '@components/Modal/FriendSearchModal';
 import { useUserContext } from '@contexts/userContext';
-import { useFollowingList, useFriendList } from '@apis/friendApi';
+import { useFollowerList, useFollowingList, useFriendList } from '@apis/friendApi';
 import { PageMain } from '@styles/common';
 import { manageBodyScroll } from '@utils';
 import {
@@ -25,6 +25,7 @@ const MyPage = () => {
 
   const { data: friendListData } = useFriendList({ jwt, size: SIZE });
   const { data: followingListData, refetch: refetchFollowingList } = useFollowingList({ jwt, size: SIZE });
+  const { data: followerListData, refetch: refetchFollowerList } = useFollowerList({ jwt });
 
   const ITEM_COUNT = 2;
   const friendList = friendListData?.pages
@@ -32,6 +33,10 @@ const MyPage = () => {
     .flat()
     .slice(0, ITEM_COUNT);
   const followingList = followingListData?.pages
+    .map((page) => page.users)
+    .flat()
+    .slice(0, ITEM_COUNT);
+  const followerList = followerListData?.pages
     .map((page) => page.users)
     .flat()
     .slice(0, ITEM_COUNT);
@@ -148,15 +153,22 @@ const MyPage = () => {
 
         <FriendSection>
           <Title>
-            <span>나에게 친구 요청 보낸 사람</span>
+            <span>친구 요청에 응답하기</span>
             <OpenModalButton>
               <Icon iconName="rightArrow" />
             </OpenModalButton>
           </Title>
 
           <ul>
-            <FriendItem type="response" userId={3} userImg="" userName="김가나" />
-            <FriendItem type="response" userId={4} userImg="" userName="김가나" />
+            {followerList?.map((user) => (
+              <FriendItem
+                key={user.id}
+                type="response"
+                userId={user.id}
+                userName={user.name}
+                userImg={user.profileUrl}
+              />
+            ))}
           </ul>
         </FriendSection>
       </FriendSectionContainer>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Icon, useModal } from 'review-me-design-system';
 import { css } from 'styled-components';
 import FriendItem from '@components/FriendItem';
+import FollowerModal from '@components/Modal/FollowerModal';
 import FollowingModal from '@components/Modal/FollowingModal';
 import FriendRequestModal from '@components/Modal/FriendRequestModal';
 import FriendSearchModal from '@components/Modal/FriendSearchModal';
@@ -23,7 +24,7 @@ const MyPage = () => {
   const SIZE = 7;
   const { user, jwt } = useUserContext();
 
-  const { data: friendListData } = useFriendList({ jwt, size: SIZE });
+  const { data: friendListData, refetch: refetchFriendList } = useFriendList({ jwt, size: SIZE });
   const { data: followingListData, refetch: refetchFollowingList } = useFollowingList({ jwt, size: SIZE });
   const { data: followerListData, refetch: refetchFollowerList } = useFollowerList({ jwt });
 
@@ -52,6 +53,7 @@ const MyPage = () => {
     close: closeFriendSearchModal,
   } = useModal();
   const { isOpen: isFollowingModalOpen, open: openFollowingModal, close: closeFollowingModal } = useModal();
+  const { isOpen: isFollowerModalOpen, open: openFollowerModal, close: closeFollowerModal } = useModal();
 
   return (
     <PageMain
@@ -154,9 +156,23 @@ const MyPage = () => {
         <FriendSection>
           <Title>
             <span>친구 요청에 응답하기</span>
-            <OpenModalButton>
+            <OpenModalButton
+              onClick={() => {
+                openFollowerModal();
+                manageBodyScroll(false);
+              }}
+            >
               <Icon iconName="rightArrow" />
             </OpenModalButton>
+            <FollowerModal
+              isOpen={isFollowerModalOpen}
+              onClose={() => {
+                closeFollowerModal();
+                manageBodyScroll(true);
+                refetchFollowerList();
+                refetchFriendList();
+              }}
+            />
           </Title>
 
           <ul>


### PR DESCRIPTION
## 개요

사용자에게 온 친구 요청을 처리할 수 있는 기능을 구현했다.

## 작업 사항

마이 페이지

- `>` 버튼을 클릭할 경우, 친구 요청에 응답하기 Modal 창이 뜬다.
- 사용자에게 친구 요청 보낸 사람 2명을 보여준다.

친구 요청에 응답하기 Modal 

- 입력한 문자열로 시작하는 이름을 가진 사용자를 검색할 수 있다.
- 검색창에 입력한 값에 해당하는 사용자들의 목록이 보인다.
- 검색창에 값을 입력하지 않았을 경우, 요청 온 사람들의 목록을 보인다.
- `x` 버튼을 클릭할 경우, Modal 창이 닫힌다.
- `수락`을 클릭할 경우
    - 친구 목록에 추가된다.
    - 목록에서 삭제된다.
- `거절`을 클릭할 경우, 목록에서 삭제된다.

## 이슈 번호

close #144 