### PR TITLE
[FE] Content 컴포넌트에 white-space 값 설정

### DIFF
--- a/src/components/Comment/style.ts
+++ b/src/components/Comment/style.ts
@@ -83,6 +83,8 @@ const SelectedLabel = styled.div`
 
 const Content = styled.span`
   ${theme.font.body.weak}
+
+  white-space: pre-wrap;
 `;
 
 const Bottom = styled.div`


### PR DESCRIPTION
## 개요

피드백, 예상질문, 댓글을 나타내는 Comment 컴포넌트에 content에서 개행 문자가 있으나 
띄어쓰기가 되지 않는 문제가 발생하여 white-space 값을 설정했다.

## 작업 사항

- Comment 컴포넌트에서 사용하는 Content 컴포넌트에 white-space 값 설정

## 이슈 번호

close #148 