### PR TITLE
[FE] 대댓글 목록에서 `더보기` 버튼을 클릭하면, 다음 페이지 데이터 fetch 해오는 기능

### DIFF
--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -1,5 +1,5 @@
 import { InfiniteData, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { REQUEST_URL } from '@constants';
+import { REPLY_LIST_SIZE, REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 
 // GET 피드백 목록 조회
@@ -117,7 +117,7 @@ export const getFeedbackReplyList = async ({
   };
 
   const response = await fetch(
-    `${REQUEST_URL.RESUME}/${resumeId}/feedback/${parentFeedbackId}?page=${pageParam}`,
+    `${REQUEST_URL.RESUME}/${resumeId}/feedback/${parentFeedbackId}?page=${pageParam}&size=${REPLY_LIST_SIZE}`,
     requestOptions,
   );
 
@@ -133,16 +133,10 @@ export const getFeedbackReplyList = async ({
 interface UseFeedbackReplyListProps {
   resumeId: number;
   parentFeedbackId: number;
-  enabled: boolean;
   jwt?: string;
 }
 
-export const useFeedbackReplyList = ({
-  resumeId,
-  parentFeedbackId,
-  enabled,
-  jwt,
-}: UseFeedbackReplyListProps) => {
+export const useFeedbackReplyList = ({ resumeId, parentFeedbackId, jwt }: UseFeedbackReplyListProps) => {
   return useInfiniteQuery({
     queryKey: ['feedbackReplyList', resumeId, parentFeedbackId],
     initialPageParam: 0,
@@ -152,7 +146,12 @@ export const useFeedbackReplyList = ({
 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
-    enabled,
+    select: (data) => {
+      return {
+        pages: [...data.pages].reverse(),
+        pageParams: [...data.pageParams].reverse(),
+      };
+    },
   });
 };
 

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -1,5 +1,5 @@
 import { InfiniteData, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { REQUEST_URL } from '@constants';
+import { REPLY_LIST_SIZE, REQUEST_URL } from '@constants';
 import { ApiResponse, PageNationData } from './response.types';
 
 interface Emoji {
@@ -119,7 +119,7 @@ export const getQuestionReplyList = async ({
   };
 
   const response = await fetch(
-    `${REQUEST_URL.RESUME}/${resumeId}/question/${parentQuestionId}?page=${pageParam}`,
+    `${REQUEST_URL.RESUME}/${resumeId}/question/${parentQuestionId}?page=${pageParam}&size=${REPLY_LIST_SIZE}`,
     requestOptions,
   );
 
@@ -135,16 +135,10 @@ export const getQuestionReplyList = async ({
 interface UseQuestionReplyListProps {
   resumeId: number;
   parentQuestionId: number;
-  enabled: boolean;
   jwt?: string;
 }
 
-export const useQuestionReplyList = ({
-  resumeId,
-  parentQuestionId,
-  enabled,
-  jwt,
-}: UseQuestionReplyListProps) => {
+export const useQuestionReplyList = ({ resumeId, parentQuestionId, jwt }: UseQuestionReplyListProps) => {
   return useInfiniteQuery({
     queryKey: ['questionReplyList', resumeId, parentQuestionId],
     initialPageParam: 0,
@@ -154,7 +148,12 @@ export const useQuestionReplyList = ({
 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
-    enabled,
+    select: (data) => {
+      return {
+        pages: [...data.pages].reverse(),
+        pageParams: [...data.pageParams].reverse(),
+      };
+    },
   });
 };
 

--- a/src/components/Reply/FeedbackReply/index.tsx
+++ b/src/components/Reply/FeedbackReply/index.tsx
@@ -220,8 +220,6 @@ const FeedbackReply = ({
 
                 const emoji = emojiList?.find(({ id: emojiId }) => emojiId === id)?.emoji;
 
-                console.log(id, myEmojiId);
-
                 return (
                   <EmojiLabelItem key={id}>
                     <EmojiLabel

--- a/src/components/ReplyList/FeedbackReplyList/index.tsx
+++ b/src/components/ReplyList/FeedbackReplyList/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import FeedbackReply from '@components/Reply/FeedbackReply';
 import ReplyAddForm from '@components/ReplyForm/ReplyAddForm';
-import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import { useUserContext } from '@contexts/userContext';
 import { FeedbackReply as FeedbackReplyType, useFeedbackReplyList } from '@apis/feedbackApi';
-import { ReplyListLayout } from '../style';
+import { MoreButton, ReplyListLayout } from '../style';
 
 interface Props {
   parentId: number;
@@ -14,19 +13,14 @@ interface Props {
 const FeedbackReplyList = ({ parentId, resumeId }: Props) => {
   const { jwt } = useUserContext();
 
-  const { data: feedbackReplyList, fetchNextPage: fetchNextFeedbackReplyList } = useFeedbackReplyList({
+  const {
+    data: feedbackReplyList,
+    fetchNextPage: fetchNextFeedbackReplyList,
+    hasNextPage,
+  } = useFeedbackReplyList({
     resumeId,
     parentFeedbackId: parentId,
-    enabled: true,
     jwt,
-  });
-  const { setTarget } = useIntersectionObserver({
-    onIntersect: () => {
-      fetchNextFeedbackReplyList();
-    },
-    options: {
-      threshold: 0.5,
-    },
   });
 
   const replies: FeedbackReplyType[] =
@@ -34,13 +28,21 @@ const FeedbackReplyList = ({ parentId, resumeId }: Props) => {
 
   return (
     <ReplyListLayout>
+      {hasNextPage && (
+        <MoreButton
+          onClick={() => {
+            fetchNextFeedbackReplyList();
+          }}
+        >
+          더보기
+        </MoreButton>
+      )}
       <ul>
         {replies.map((reply) => (
           <li key={reply.id}>
             <FeedbackReply resumeId={resumeId} {...reply} />
           </li>
         ))}
-        <div ref={setTarget}></div>
       </ul>
       <ReplyAddForm type="feedback" resumeId={resumeId} parentId={parentId} />
     </ReplyListLayout>

--- a/src/components/ReplyList/QuestionReplyList/index.tsx
+++ b/src/components/ReplyList/QuestionReplyList/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import QuestionReply from '@components/Reply/QuestionReply';
 import ReplyAddForm from '@components/ReplyForm/ReplyAddForm';
-import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import { useUserContext } from '@contexts/userContext';
 import { QuestionReply as QuestionReplyType, useQuestionReplyList } from '@apis/questionApi';
-import { ReplyListLayout } from '../style';
+import { MoreButton, ReplyListLayout } from '../style';
 
 interface Props {
   parentId: number;
@@ -14,19 +13,14 @@ interface Props {
 const QuestionReplyList = ({ parentId, resumeId }: Props) => {
   const { jwt } = useUserContext();
 
-  const { data: questionReplyList, fetchNextPage: fetchNextQuestionReplyList } = useQuestionReplyList({
+  const {
+    data: questionReplyList,
+    fetchNextPage: fetchNextQuestionReplyList,
+    hasNextPage,
+  } = useQuestionReplyList({
     resumeId,
     parentQuestionId: parentId,
-    enabled: true,
     jwt,
-  });
-  const { setTarget } = useIntersectionObserver({
-    onIntersect: () => {
-      fetchNextQuestionReplyList();
-    },
-    options: {
-      threshold: 0.5,
-    },
   });
 
   const replies: QuestionReplyType[] =
@@ -34,13 +28,21 @@ const QuestionReplyList = ({ parentId, resumeId }: Props) => {
 
   return (
     <ReplyListLayout>
+      {hasNextPage && (
+        <MoreButton
+          onClick={() => {
+            fetchNextQuestionReplyList();
+          }}
+        >
+          더보기
+        </MoreButton>
+      )}
       <ul>
         {replies.map((reply) => (
           <li key={reply.id}>
             <QuestionReply resumeId={resumeId} {...reply} />
           </li>
         ))}
-        <div ref={setTarget}></div>
       </ul>
       <ReplyAddForm type="question" resumeId={resumeId} parentId={parentId} />
     </ReplyListLayout>

--- a/src/components/ReplyList/style.ts
+++ b/src/components/ReplyList/style.ts
@@ -9,4 +9,15 @@ const ReplyListLayout = styled.div`
   background-color: ${theme.palette.green100};
 `;
 
-export { ReplyListLayout };
+const MoreButton = styled.button`
+  margin: auto;
+
+  background-color: transparent;
+
+  ${theme.font.button.weak}
+  color: ${theme.palette.gray600};
+
+  cursor: pointer;
+`;
+
+export { ReplyListLayout, MoreButton };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -30,3 +30,5 @@ export const PDF_VIEWER_SCALE = {
 } as const;
 
 export const IS_LOGGED_IN_KEY = 'isLoggedIn';
+
+export const REPLY_LIST_SIZE = 4;


### PR DESCRIPTION
## 개요

대댓글 목록에 `더보기` 버튼을 추가했다.

## 작업 사항

- 피드백 대댓글 목록에 `더보기` 버튼 추가
  - `더보기` 버튼을 클릭하면, 다음 페이지에 피드백 대댓글 목록이 불러와진다. 
- 예상질문 대댓글 목록에 `더보기` 버튼 추가
   - `더보기` 버튼을 클릭하면, 다음 페이지에 예상질문 대댓글 목록이 불러와진다. 

## 이슈 번호

close #152 
