### PR TITLE
[FE] FriendItem 컴포넌트 네이밍과 prop 변경

### DIFF
--- a/src/components/Modal/FollowerModal/index.tsx
+++ b/src/components/Modal/FollowerModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Icon, Input, Modal } from 'review-me-design-system';
-import FriendItem from '@components/FriendItem';
+import UserItem from '@components/UserItem';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useMediaQuery from '@hooks/useMediaQuery';
 import { useUserContext } from '@contexts/userContext';
@@ -66,7 +66,7 @@ const FollowerModal = ({ isOpen, onClose }: Props) => {
       {followerList && followerList.length > 0 && (
         <UserList>
           {followerList.map((user) => (
-            <FriendItem
+            <UserItem
               key={user.id}
               type="response"
               userId={user.id}

--- a/src/components/Modal/FollowerModal/index.tsx
+++ b/src/components/Modal/FollowerModal/index.tsx
@@ -68,7 +68,7 @@ const FollowerModal = ({ isOpen, onClose }: Props) => {
           {followerList.map((user) => (
             <UserItem
               key={user.id}
-              type="response"
+              type="follower"
               userId={user.id}
               userImg={user.profileUrl}
               userName={user.name}

--- a/src/components/Modal/FollowingModal/index.tsx
+++ b/src/components/Modal/FollowingModal/index.tsx
@@ -72,7 +72,7 @@ const FollowingModal = ({ isOpen, onClose }: Props) => {
           {followingList.map((user) => (
             <UserItem
               key={user.id}
-              type="request"
+              type="following"
               userId={user.id}
               userImg={user.profileUrl}
               userName={user.name}

--- a/src/components/Modal/FollowingModal/index.tsx
+++ b/src/components/Modal/FollowingModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Icon, Input, Modal } from 'review-me-design-system';
-import FriendItem from '@components/FriendItem';
+import UserItem from '@components/UserItem';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useMediaQuery from '@hooks/useMediaQuery';
 import { useUserContext } from '@contexts/userContext';
@@ -70,7 +70,7 @@ const FollowingModal = ({ isOpen, onClose }: Props) => {
       {followingList && followingList.length > 0 && (
         <UserList>
           {followingList.map((user) => (
-            <FriendItem
+            <UserItem
               key={user.id}
               type="request"
               userId={user.id}

--- a/src/components/Modal/FriendRequestModal/index.tsx
+++ b/src/components/Modal/FriendRequestModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Icon, Input, Modal } from 'review-me-design-system';
-import FriendItem from '@components/FriendItem';
+import UserItem from '@components/UserItem';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useMediaQuery from '@hooks/useMediaQuery';
 import { useUserContext } from '@contexts/userContext';
@@ -66,7 +66,7 @@ const FriendRequestModal = ({ isOpen, onClose }: Props) => {
       {name.length > 0 && userList && userList.length > 0 && (
         <UserList>
           {userList.map((user) => (
-            <FriendItem
+            <UserItem
               key={user.id}
               type="none"
               userId={user.id}

--- a/src/components/Modal/FriendSearchModal/index.tsx
+++ b/src/components/Modal/FriendSearchModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Icon, Input, Modal } from 'review-me-design-system';
-import FriendItem from '@components/FriendItem';
+import UserItem from '@components/UserItem';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useMediaQuery from '@hooks/useMediaQuery';
 import { useUserContext } from '@contexts/userContext';
@@ -69,7 +69,7 @@ const FriendSearchModal = ({ isOpen, onClose }: Props) => {
       {name.length === 0 && (
         <FriendList>
           {friendList?.map((friend) => (
-            <FriendItem
+            <UserItem
               key={friend.id}
               type="friend"
               userId={friend.id}
@@ -83,7 +83,7 @@ const FriendSearchModal = ({ isOpen, onClose }: Props) => {
       {name.length > 0 && friendList && friendList.length > 0 && (
         <FriendList>
           {friendList.map((friend) => (
-            <FriendItem
+            <UserItem
               key={friend.id}
               type="friend"
               userId={friend.id}

--- a/src/components/UserItem/index.tsx
+++ b/src/components/UserItem/index.tsx
@@ -9,7 +9,7 @@ import {
   useRejectFriendRequest,
 } from '@apis/friendApi';
 import { manageBodyScroll } from '@utils';
-import { ButtonsContainer, FriendItemLayout, UserImg, UserInfo, UserName } from './style';
+import { ButtonsContainer, UserItemLayout, UserImg, UserInfo, UserName } from './style';
 
 type Type = 'friend' | 'request' | 'response' | 'none';
 
@@ -20,7 +20,7 @@ interface Props {
   userName: string;
 }
 
-const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
+const UserItem = ({ type: initType, userId, userImg, userName }: Props) => {
   const { jwt } = useUserContext();
 
   const [type, setType] = useState<Type>(initType);
@@ -36,7 +36,7 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
   const { mutate: rejectFriendRequest } = useRejectFriendRequest();
 
   return (
-    <FriendItemLayout>
+    <UserItemLayout>
       <UserInfo>
         <UserImg src={userImg} alt={userName} />
         <UserName>{userName}</UserName>
@@ -110,8 +110,8 @@ const FriendItem = ({ type: initType, userId, userImg, userName }: Props) => {
           </Button>
         </ButtonsContainer>
       )}
-    </FriendItemLayout>
+    </UserItemLayout>
   );
 };
 
-export default FriendItem;
+export default UserItem;

--- a/src/components/UserItem/index.tsx
+++ b/src/components/UserItem/index.tsx
@@ -11,7 +11,7 @@ import {
 import { manageBodyScroll } from '@utils';
 import { ButtonsContainer, UserItemLayout, UserImg, UserInfo, UserName } from './style';
 
-type Type = 'friend' | 'request' | 'response' | 'none';
+type Type = 'friend' | 'following' | 'follower' | 'none';
 
 interface Props {
   type: Type;
@@ -48,7 +48,7 @@ const UserItem = ({ type: initType, userId, userImg, userName }: Props) => {
           size="s"
           onClick={() => {
             if (jwt) requestFriend({ userId, jwt });
-            setType('request');
+            setType('following');
           }}
         >
           친구 요청
@@ -76,7 +76,7 @@ const UserItem = ({ type: initType, userId, userImg, userName }: Props) => {
           />
         </>
       )}
-      {type === 'request' && (
+      {type === 'following' && (
         <Button
           variant="outline"
           size="s"
@@ -88,7 +88,7 @@ const UserItem = ({ type: initType, userId, userImg, userName }: Props) => {
           요청 취소
         </Button>
       )}
-      {type === 'response' && (
+      {type === 'follower' && (
         <ButtonsContainer>
           <Button
             variant="default"

--- a/src/components/UserItem/style.ts
+++ b/src/components/UserItem/style.ts
@@ -2,7 +2,7 @@ import { theme } from 'review-me-design-system';
 import styled from 'styled-components';
 import { ellipsisStyles } from '@styles/common';
 
-const FriendItemLayout = styled.li`
+const UserItemLayout = styled.li`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -58,4 +58,4 @@ const SkeletonUserName = styled.div`
   background-color: ${theme.color.neutral.bg.light};
 `;
 
-export { FriendItemLayout, UserInfo, UserImg, UserName, ButtonsContainer, SkeletonImg, SkeletonUserName };
+export { UserItemLayout, UserInfo, UserImg, UserName, ButtonsContainer, SkeletonImg, SkeletonUserName };

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Button, Icon, useModal } from 'review-me-design-system';
 import { css } from 'styled-components';
-import FriendItem from '@components/FriendItem';
 import FollowerModal from '@components/Modal/FollowerModal';
 import FollowingModal from '@components/Modal/FollowingModal';
 import FriendRequestModal from '@components/Modal/FriendRequestModal';
 import FriendSearchModal from '@components/Modal/FriendSearchModal';
+import UserItem from '@components/UserItem';
 import { useUserContext } from '@contexts/userContext';
 import { useFollowerList, useFollowingList, useFriendList } from '@apis/friendApi';
 import { PageMain } from '@styles/common';
@@ -108,7 +108,7 @@ const MyPage = () => {
 
           <ul>
             {friendList?.map((friend) => (
-              <FriendItem
+              <UserItem
                 type="friend"
                 key={friend.id}
                 userId={friend.id}
@@ -142,7 +142,7 @@ const MyPage = () => {
 
           <ul>
             {followingList?.map((user) => (
-              <FriendItem
+              <UserItem
                 key={user.id}
                 type="request"
                 userId={user.id}
@@ -177,7 +177,7 @@ const MyPage = () => {
 
           <ul>
             {followerList?.map((user) => (
-              <FriendItem
+              <UserItem
                 key={user.id}
                 type="response"
                 userId={user.id}

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -144,7 +144,7 @@ const MyPage = () => {
             {followingList?.map((user) => (
               <UserItem
                 key={user.id}
-                type="request"
+                type="following"
                 userId={user.id}
                 userName={user.name}
                 userImg={user.profileUrl}
@@ -179,7 +179,7 @@ const MyPage = () => {
             {followerList?.map((user) => (
               <UserItem
                 key={user.id}
-                type="response"
+                type="follower"
                 userId={user.id}
                 userName={user.name}
                 userImg={user.profileUrl}


### PR DESCRIPTION
## 개요

FriendItem 컴포넌트의 네이밍과 prop 타입을 수정했다.

## 작업 사항

- UserItem으로 이름 변경
- type은 `friend`, `follower`, `following`, `none` 중 하나다.
  - `friend`: 친구 관계
  - `follower`: 내가 친구 요청 보낸 사람
  - `following`: 나에게 친구 요청 보낸 사람
  - `none`: 나머지

## 이슈 번호

close #156 