### PR TITLE
[FE] 마이페이지에 진입하면 친구 목록 조회가 2번 요청가는 문제 해결

### DIFF
--- a/src/components/Modal/FriendSearchModal/index.tsx
+++ b/src/components/Modal/FriendSearchModal/index.tsx
@@ -34,6 +34,8 @@ const FriendSearchModal = ({ isOpen, onClose }: Props) => {
   const friendList = friendListData?.pages.map((page) => page.users).flat();
 
   useEffect(() => {
+    if (name.length === 0) return;
+
     const timer = setTimeout(() => {
       refetch();
     }, 500);


### PR DESCRIPTION
## 개요

마이페이지에 진입하면 친구 목록 조회가 2번 요청이 발생했다.
`FriendSearchModal`의 useEffect 콜백에 if문을 걸어 불필요한 요청을 방지할 수 있었다.

## 작업 사항

- `FriendSearchModal`에서 input에 아무런 값을 입력하지 않을 경우, refetch가 일어나지 않도록 if문 설정

## 이슈 번호

close #158 
