### PR TITLE
[FE] 이력서 수정 form / 업로드 form에서 submit이 되지 않는 문제 해결

### DIFF
--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -136,6 +136,7 @@ interface GetResumeDetail {
   writerName: string;
   writerProfileUrl: string;
   occupation: string;
+  scope: string;
   year: number;
 }
 

--- a/src/apis/utilApi.ts
+++ b/src/apis/utilApi.ts
@@ -27,7 +27,12 @@ export const getOccupationList = async () => {
 };
 
 export const useOccupationList = () => {
-  return useQuery({ queryKey: ['occupationList'], queryFn: getOccupationList });
+  return useQuery({
+    queryKey: ['occupationList'],
+    queryFn: getOccupationList,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
 };
 
 // GET 공개 범위 목록 조회
@@ -55,7 +60,7 @@ export const getScopeList = async () => {
 };
 
 export const useScopeList = () => {
-  return useQuery({ queryKey: ['scopeList'], queryFn: getScopeList });
+  return useQuery({ queryKey: ['scopeList'], queryFn: getScopeList, staleTime: Infinity, gcTime: Infinity });
 };
 
 // GET 이모지 목록 조회

--- a/src/components/MyResumeItem/index.tsx
+++ b/src/components/MyResumeItem/index.tsx
@@ -43,7 +43,7 @@ const MyResumeItem = ({ id, title, year, occupation, scope, createdAt }: Props) 
         <Button
           $position="left"
           onClick={() => {
-            navigate(ROUTE_PATH.RESUME_UPDATE, { state: { resumeId: id, title, year, occupation, scope } });
+            navigate(`${ROUTE_PATH.RESUME_UPDATE}/${id}`);
           }}
         >
           수정

--- a/src/components/ResumeForm/ResumeUpdateForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUpdateForm/index.tsx
@@ -36,7 +36,7 @@ const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupation, initScope
   const [title, setTitle] = useState<string>(initTitle);
   const [occupationId, setOccupationId] = useState<number | undefined>(initOccupationId);
   const [scopeId, setScopeId] = useState<number | undefined>(initScopeId);
-  const [year, setYear] = useState<number | undefined>(initYear);
+  const [year, setYear] = useState<number>(initYear);
 
   const { mutate: updateResume } = useUpdateResume();
 
@@ -47,7 +47,8 @@ const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupation, initScope
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!jwt || !occupationId || !scopeId || title.length === 0 || !year) return;
+
+    if (!jwt || !occupationId || !scopeId || title.length === 0 || year < 0) return;
 
     updateResume(
       {

--- a/src/components/ResumeForm/ResumeUpdateForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUpdateForm/index.tsx
@@ -17,12 +17,12 @@ interface Props {
   resumeId: number;
   file?: string;
   initTitle: string;
-  initOccupation: string;
-  initScope: string;
+  initOccupationId: number;
+  initScopeId: number;
   initYear: number;
 }
 
-const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupation, initScope, initYear }: Props) => {
+const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupationId, initScopeId, initYear }: Props) => {
   const navigate = useNavigate();
 
   const { data: occupationList } = useOccupationList();
@@ -30,12 +30,9 @@ const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupation, initScope
 
   const { jwt } = useUserContext();
 
-  const initOccupationId = occupationList?.find(({ occupation }) => occupation === initOccupation)?.id;
-  const initScopeId = scopeList?.find(({ scope }) => scope === initScope)?.id;
-
   const [title, setTitle] = useState<string>(initTitle);
-  const [occupationId, setOccupationId] = useState<number | undefined>(initOccupationId);
-  const [scopeId, setScopeId] = useState<number | undefined>(initScopeId);
+  const [occupationId, setOccupationId] = useState<number>(initOccupationId);
+  const [scopeId, setScopeId] = useState<number>(initScopeId);
   const [year, setYear] = useState<number>(initYear);
 
   const { mutate: updateResume } = useUpdateResume();
@@ -102,11 +99,6 @@ const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupation, initScope
               name="scope"
               defaultValue={scopeId}
               onChange={(e) => {
-                if (e.target.value === 'none') {
-                  setScopeId(undefined);
-                  return;
-                }
-
                 const value = Number(e.target.value);
                 if (Number.isNaN(value)) return;
 
@@ -131,11 +123,6 @@ const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupation, initScope
               name="occupation"
               defaultValue={occupationId}
               onChange={(e) => {
-                if (e.target.value === 'none') {
-                  setOccupationId(undefined);
-                  return;
-                }
-
                 const value = Number(e.target.value);
                 if (Number.isNaN(value)) return;
 

--- a/src/components/ResumeForm/ResumeUploadForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUploadForm/index.tsx
@@ -40,7 +40,7 @@ const ResumeUploadForm = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!jwt || !file || !occupationId || !scopeId || title.length === 0 || !year) return;
+    if (!jwt || !file || !occupationId || !scopeId || title.length === 0 || typeof year !== 'number') return;
 
     addResume(
       {

--- a/src/pages/ResumeUpdate/index.tsx
+++ b/src/pages/ResumeUpdate/index.tsx
@@ -1,27 +1,26 @@
 import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Icon } from 'review-me-design-system';
 import ResumeUpdateForm from '@components/ResumeForm/ResumeUpdateForm';
 import { useUserContext } from '@contexts/userContext';
 import { useResumeDetail } from '@apis/resumeApi';
+import { useOccupationList, useScopeList } from '@apis/utilApi';
 import { PageMain } from '@styles/common';
 import { ResumeUploadContainer, IconButton, Description, MainDescription, SubDescription } from './style';
 
-interface Location {
-  state: { resumeId: number; title: string; year: number; occupation: string; scope: string };
-}
-
 const ResumeUpdate = () => {
-  const {
-    state: { resumeId, title: initTitle, year: initYear, occupation: initOccupation, scope: initScope },
-  } = useLocation() as Location;
+  const { resumeId } = useParams();
   const { jwt } = useUserContext();
 
   const navigate = useNavigate();
 
-  const { data: resumeDetail } = useResumeDetail({ resumeId, jwt });
+  const { data: resumeDetail } = useResumeDetail({ resumeId: Number(resumeId), jwt });
+  const { data: occupationList } = useOccupationList();
+  const { data: scopeList } = useScopeList();
 
-  const file = resumeDetail?.resumeUrl;
+  const initOccupationId = occupationList?.find(({ occupation }) => occupation === resumeDetail?.occupation)
+    ?.id;
+  const initScopeId = scopeList?.find(({ scope }) => scope === resumeDetail?.scope)?.id;
 
   return (
     <PageMain>
@@ -36,14 +35,16 @@ const ResumeUpdate = () => {
           <SubDescription>아래의 양식을 작성하고 수정하기 버튼을 눌러주세요.</SubDescription>
         </Description>
 
-        <ResumeUpdateForm
-          resumeId={resumeId}
-          file={file}
-          initTitle={initTitle}
-          initOccupation={initOccupation}
-          initScope={initScope}
-          initYear={initYear}
-        />
+        {resumeDetail && initOccupationId && initScopeId && (
+          <ResumeUpdateForm
+            resumeId={Number(resumeId)}
+            file={resumeDetail.resumeUrl}
+            initTitle={resumeDetail.title}
+            initOccupationId={initOccupationId}
+            initScopeId={initScopeId}
+            initYear={resumeDetail.year}
+          />
+        )}
       </ResumeUploadContainer>
     </PageMain>
   );

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -50,12 +50,8 @@ const router = createBrowserRouter([
         element: <ResumeUpload />,
       },
       {
-        path: ROUTE_PATH.RESUME_UPDATE,
-        element: (
-          <TokenRefresh>
-            <ResumeUpdate />
-          </TokenRefresh>
-        ),
+        path: `${ROUTE_PATH.RESUME_UPDATE}/:resumeId`,
+        element: <ResumeUpdate />,
       },
     ],
   },


### PR DESCRIPTION
## 개요

이력서 수정 Form과 이력서 업로드 Form에서 submit이 안되는 문제가 발생했다. (원인은 이슈에 작성)

## 작업 사항

- `ResumeUpdateForm`의 `handleSubmit` if문 수정
- `ResumeUploadForm`의 `handleSubmit` if문 수정
- 직군 목록을 조회하는 query의 staleTime과 gcTime 설정
- 공개 범위 목록을 조회하는 query의 staleTime과 gcTime 설정
- `ResumeUpdateForm` prop 수정

#### 이력서 수정 페이지 flow

1. `/resume-update/:resumeId`에서 resumeId로 이력서 상세 조회를 한다.
2. 직군(`occupationList`)과 공개 범위(`scopeList`)를 조회한다.
3. 1번에서 응답으로 온 `occupation`과 `scope`로, 2번에서 얻은 데이터에서 `occupationId`와 `scopeId` 값을 구한다.
4. `occupationId`와 `scopeId`을 prop으로 `ResumeUpdateForm`에게 넘겨준다.

## 이슈 번호

close #160 
