### PR TITLE
[FE] 친구 요청 수락할 경우, 친구 목록에 대한 queryKey 무효화 

### DIFF
--- a/src/apis/friendApi.ts
+++ b/src/apis/friendApi.ts
@@ -269,7 +269,10 @@ export const useAcceptFriendRequest = () => {
   return useMutation({
     mutationFn: acceptFriendRequest,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['followerList'] });
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['followerList'] }),
+        queryClient.invalidateQueries({ queryKey: ['friendList'] }),
+      ]);
     },
   });
 };


### PR DESCRIPTION
## 개요

`useAcceptFriendRequest`의 `onSuccess` 수정

## 작업 사항

- 친구 요청을 수락할 경우, followerList queryKey 무효화

## 이슈 번호

close #167 