### PR TITLE
[FE] 이력서 목록 skeleton UI 생성

### DIFF
--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -1,4 +1,10 @@
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { apiClient } from './apiClient';
 import { PageNationData } from './response.types';
@@ -62,7 +68,7 @@ interface UseResumeListProps {
 export const useResumeList = ({ jwt, occupationId, startYear, endYear }: UseResumeListProps) => {
   const yearFilter = { startYear, endYear };
 
-  return useInfiniteQuery({
+  return useSuspenseInfiniteQuery({
     queryKey: ['resumeList', occupationId, yearFilter],
     initialPageParam: 0,
     queryFn: ({ pageParam }) => getResumeList({ pageParam, jwt, occupationId, startYear, endYear }),

--- a/src/components/DelayedComponent/index.tsx
+++ b/src/components/DelayedComponent/index.tsx
@@ -1,0 +1,25 @@
+import React, { ReactNode, useEffect, useState } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+const DelayedComponent = ({ children }: Props) => {
+  const [show, setShow] = useState<boolean>(false);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setShow(true);
+    }, 200);
+
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  if (!show) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+export default DelayedComponent;

--- a/src/components/ResumeItem/skeleton.tsx
+++ b/src/components/ResumeItem/skeleton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { SkeletonBox, SkeletonUserImg } from '@styles/skeleton';
+import { SkeletonResumeItemLayout, User } from './style';
+
+const SkeletonResumeItem = () => {
+  return (
+    <SkeletonResumeItemLayout>
+      <SkeletonBox $height="2rem" />
+      <User>
+        <SkeletonUserImg $width="2.25rem" $height="2.25rem" />
+        <SkeletonBox $width="50%" $height="1.75rem" />
+      </User>
+      <SkeletonBox $height="3.5rem" />
+      <SkeletonBox $height="1.75rem" />
+    </SkeletonResumeItemLayout>
+  );
+};
+
+export default SkeletonResumeItem;

--- a/src/components/ResumeItem/style.ts
+++ b/src/components/ResumeItem/style.ts
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
 import { theme } from 'review-me-design-system';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { ellipsisStyles } from '@styles/common';
 
-const ResumeItemLayout = styled(Link)`
+const resumeItemLayoutStyles = css`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -12,6 +12,10 @@ const ResumeItemLayout = styled(Link)`
   background-color: ${theme.color.neutral.bg.default};
   border-radius: 1rem;
   box-shadow: 0 0 1.5rem -0.25rem rgba(16, 24, 40, 0.08);
+`;
+
+const ResumeItemLayout = styled(Link)`
+  ${resumeItemLayoutStyles}
 
   color: ${theme.color.neutral.text.default};
   ${theme.font.body.default};
@@ -39,7 +43,6 @@ const UserImg = styled.img`
   height: 2.25rem;
 
   border-radius: 50%;
-  border: 0.0625rem solid ${theme.color.accent.bd.strong};
 `;
 
 const UserInfo = styled.div`
@@ -56,4 +59,9 @@ const CreatedAt = styled.span`
   color: ${theme.palette.gray500};
 `;
 
-export { ResumeItemLayout, Title, User, UserImg, UserInfo, CreatedAt };
+// skeleton 스타일
+const SkeletonResumeItemLayout = styled.div`
+  ${resumeItemLayoutStyles}
+`;
+
+export { ResumeItemLayout, Title, User, UserImg, UserInfo, CreatedAt, SkeletonResumeItemLayout };

--- a/src/components/ResumeList/index.tsx
+++ b/src/components/ResumeList/index.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import ResumeItem from '@components/ResumeItem';
+import useIntersectionObserver from '@hooks/useIntersectionObserver';
+import { useUserContext } from '@contexts/userContext';
+import { useResumeList } from '@apis/resumeApi';
+import { ResumeListLayout } from './style';
+
+interface Props {
+  occupationId?: number;
+  startYear: number;
+  endYear: number;
+}
+
+const ResumeList = ({ occupationId, startYear, endYear }: Props) => {
+  const { jwt } = useUserContext();
+  const { data: resumeListData, fetchNextPage } = useResumeList({
+    jwt,
+    occupationId,
+    startYear,
+    endYear,
+  });
+
+  const resumeList = resumeListData?.pages.flatMap((page) => page.resumes);
+
+  const { setTarget } = useIntersectionObserver({
+    onIntersect: () => fetchNextPage(),
+    options: {
+      threshold: 0.5,
+    },
+  });
+
+  return (
+    <>
+      <ResumeListLayout>
+        {resumeList?.map((resume) => {
+          return (
+            <li key={resume.id}>
+              <ResumeItem {...resume} />
+            </li>
+          );
+        })}
+      </ResumeListLayout>
+      <div ref={setTarget}></div>
+    </>
+  );
+};
+
+export default ResumeList;

--- a/src/components/ResumeList/skeleton.tsx
+++ b/src/components/ResumeList/skeleton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import SkeletonResumeItem from '@components/ResumeItem/skeleton';
+import { ResumeListLayout } from './style';
+
+const SkeletonResumeList = () => {
+  return (
+    <ResumeListLayout>
+      <SkeletonResumeItem />
+      <SkeletonResumeItem />
+      <SkeletonResumeItem />
+      <SkeletonResumeItem />
+      <SkeletonResumeItem />
+      <SkeletonResumeItem />
+    </ResumeListLayout>
+  );
+};
+
+export default SkeletonResumeList;

--- a/src/components/ResumeList/style.ts
+++ b/src/components/ResumeList/style.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import { breakPoints } from '@styles/common';
+
+const ResumeListLayout = styled.ul`
+  display: grid;
+  width: 100%;
+
+  @media ${breakPoints.desktop} {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1.5rem;
+  }
+  @media ${breakPoints.tablet} {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.5rem;
+  }
+  @media ${breakPoints.mobile} {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem 0.625rem;
+  }
+`;
+
+export { ResumeListLayout };

--- a/src/pages/Resume/style.ts
+++ b/src/pages/Resume/style.ts
@@ -46,22 +46,4 @@ const YearRange = styled.button`
   color: ${({ theme }) => theme.color.neutral.text.default};
 `;
 
-const ResumeList = styled.ul`
-  display: grid;
-  width: 100%;
-
-  @media ${breakPoints.desktop} {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 1.5rem;
-  }
-  @media ${breakPoints.tablet} {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1.5rem;
-  }
-  @media ${breakPoints.mobile} {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1rem 0.625rem;
-  }
-`;
-
-export { MainHeader, FilterContainer, Filter, YearRange, ResumeList };
+export { MainHeader, FilterContainer, Filter, YearRange };

--- a/src/styles/skeleton.ts
+++ b/src/styles/skeleton.ts
@@ -1,0 +1,19 @@
+import { theme } from 'review-me-design-system';
+import styled from 'styled-components';
+
+export const SkeletonBox = styled.div<{ $width?: string; $height: string }>`
+  width: ${({ $width }) => $width || '100%'};
+  height: ${({ $height }) => $height};
+
+  border-radius: 0.5rem;
+  background-color: ${theme.palette.gray200};
+`;
+
+export const SkeletonUserImg = styled.div<{ $width: string; $height: string }>`
+  flex-shrink: 0;
+  width: ${({ $width }) => $width};
+  height: ${({ $height }) => $height};
+
+  border-radius: 50%;
+  background-color: ${theme.palette.gray200};
+`;


### PR DESCRIPTION
## 개요

이력서 목록이 로딩됨을 보여주기 위해 skeleton UI를 만들었다.

## 작업 사항

- 이력서 목록 skeleton UI 생성
- DelayedComponent 생성
  - 200ms초가 지나면 하위 컴포넌트를 보여줌

### skeleton ui 깜빡임

아래 그림은 Suspense를 적용했다. 평균적으로 이력서 목록을 요청하고 응답이 오는데까지 30~60ms 정도 걸린다.
빠르게 데이터가 오기 때문에 skeleton ui가 금방 사라진다.
![skeleton](https://github.com/review-me-Team/review-me-fe/assets/96980857/a5f06d15-73d6-4032-bb40-38bf858983e3)

따라서 `DelayedComponent`를 통해 200ms 이전에는 빈 화면을 보여주고, 이후에는 skeleton ui를 보여주도록 구현했다.
즉, 로딩시간이 200ms보다 길어진다면 `응답이 오기까지 걸리는 시간 - 200ms`동안 skeleton ui이 보인다.

## 이슈 번호

close #173 
