### PR TITLE
[FE] 로그인 모달창을 닫으면 body의 overflow 값 변경

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -172,7 +172,13 @@ const Header = () => {
           </RightContainer>
         </NavContainer>
       </HeaderLayout>
-      <LoginRequestModal isOpen={isOpenLoginRequestModal} onClose={closeLoginRequestModal} />
+      <LoginRequestModal
+        isOpen={isOpenLoginRequestModal}
+        onClose={() => {
+          closeLoginRequestModal();
+          manageBodyScroll(true);
+        }}
+      />
     </>
   );
 };


### PR DESCRIPTION
## 개요

#183 에서 로그인 모달창이 열린 상태에서 외부를 클릭해 닫을 경우, body에 스크롤이 작동하지 않는 문제가 발생했다.
닫을 때 body의 `overflow: auto`로 값을 변경하여 스크롤이 가능하도록 구현했다.

## 작업 사항

## 이슈 번호

#182 