### PR TITLE
[FE] 경력이 0이면 이력서 등록 / 수정이 안되는 문제 해결

### DIFF
--- a/src/components/ResumeForm/ResumeUpdateForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUpdateForm/index.tsx
@@ -55,7 +55,7 @@ const ResumeUpdateForm = ({ resumeId, file, initTitle, initOccupationId, initSco
       return;
     }
 
-    if (!(year && validateYear(year))) {
+    if (!(typeof year === 'number' && validateYear(year))) {
       openToast({ type: 'error', message: FAILURE_MESSAGE.RESUME.INVALID_YEAR });
       return;
     }

--- a/src/components/ResumeForm/ResumeUploadForm/index.tsx
+++ b/src/components/ResumeForm/ResumeUploadForm/index.tsx
@@ -71,7 +71,7 @@ const ResumeUploadForm = () => {
       return;
     }
 
-    if (!(year && validateYear(year))) {
+    if (!(typeof year === 'number' && validateYear(year))) {
       openToast({ type: 'error', message: FAILURE_MESSAGE.RESUME.INVALID_YEAR });
       return;
     }


### PR DESCRIPTION
## 개요

0이 falsy 값이므로 if문에서 false로 평가된다. 따라서 year의 타입이 number이고 0이상이면 HTTP 요청을 보낼 수 있도록 수정했다.

## 작업 사항

- submit 핸들러에서 year 조건문 수정

## 이슈 번호

close #160 