### PR TITLE
[FE] IconButton 컴포넌트에 aria-label 설정

### DIFF
--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -118,7 +118,11 @@ const Comment = ({
             <ButtonsContainer>
               {isCommenterUser && (
                 <MoreIconContainer>
-                  <IconButton onClick={openDropdown} disabled={content === null}>
+                  <IconButton
+                    aria-label="댓글 옵션 메뉴 열기"
+                    onClick={openDropdown}
+                    disabled={content === null}
+                  >
                     <Icon
                       iconName="more"
                       width={ICON_SIZE}

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -153,7 +153,11 @@ const Feedback = ({
 
           {!isEdited && (
             <ButtonsContainer>
-              <IconButton onClick={handleCheckMarkClick} disabled={content === null}>
+              <IconButton
+                aria-label={checked ? '체크 표시 취소' : '체크 표시'}
+                onClick={handleCheckMarkClick}
+                disabled={content === null}
+              >
                 {checked ? (
                   <Icon
                     iconName="filledCheckMark"
@@ -172,7 +176,11 @@ const Feedback = ({
               </IconButton>
               {isCommenterUser && (
                 <MoreIconContainer>
-                  <IconButton onClick={openDropdown} disabled={content === null}>
+                  <IconButton
+                    aria-label="피드백 옵션 메뉴 열기"
+                    onClick={openDropdown}
+                    disabled={content === null}
+                  >
                     <Icon
                       iconName="more"
                       width={ICON_SIZE}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -70,12 +70,12 @@ const Header = () => {
         <NavContainer>
           {isMobile && (
             <>
-              <IconButton onClick={handleOpenMobileMenu}>
+              <IconButton aria-label="메뉴 열기" onClick={handleOpenMobileMenu}>
                 <Icon iconName="menu" color={theme.color.accent.text.strong} width={28} height={28} />
               </IconButton>
               <MobileMenu className={isOpenMobileMenu ? 'open' : ''}>
                 <MobileMenuTop>
-                  <IconButton onClick={handleCloseMobileMenu}>
+                  <IconButton aria-label="메뉴 닫기" onClick={handleCloseMobileMenu}>
                     <Icon iconName="xMark" width={28} height={28} />
                   </IconButton>
                 </MobileMenuTop>
@@ -153,6 +153,7 @@ const Header = () => {
 
           <RightContainer>
             <IconButton
+              aria-label="마이페이지로 이동"
               onClick={() => {
                 if (!isLoggedIn) {
                   openLoginRequestModal();

--- a/src/components/Modal/FollowerModal/index.tsx
+++ b/src/components/Modal/FollowerModal/index.tsx
@@ -55,7 +55,7 @@ const FollowerModal = ({ isOpen, onClose }: Props) => {
     <Modal modalRootId="modal-root" isOpen={isOpen} onClose={handleClose} width={isMobile ? '80%' : '34rem'}>
       <Header>
         <Modal.Title>친구 요청에 응답하기</Modal.Title>
-        <IconButton onClick={handleClose}>
+        <IconButton aria-label="친구 요청에 응답하기 모달 닫기" onClick={handleClose}>
           <Icon iconName="xMark" />
         </IconButton>
       </Header>

--- a/src/components/Modal/FollowingModal/index.tsx
+++ b/src/components/Modal/FollowingModal/index.tsx
@@ -56,7 +56,7 @@ const FollowingModal = ({ isOpen, onClose }: Props) => {
     <Modal modalRootId="modal-root" isOpen={isOpen} onClose={handleClose} width={isMobile ? '80%' : '34rem'}>
       <Header>
         <Modal.Title>전송한 친구 요청 보기</Modal.Title>
-        <IconButton onClick={handleClose}>
+        <IconButton aria-label="전송한 친구 요청 보기 모달 닫기" onClick={handleClose}>
           <Icon iconName="xMark" />
         </IconButton>
       </Header>

--- a/src/components/Modal/FriendRequestModal/index.tsx
+++ b/src/components/Modal/FriendRequestModal/index.tsx
@@ -55,7 +55,7 @@ const FriendRequestModal = ({ isOpen, onClose }: Props) => {
     <Modal modalRootId="modal-root" isOpen={isOpen} onClose={handleClose} width={isMobile ? '80%' : '34rem'}>
       <Header>
         <Modal.Title>친구 추가하기</Modal.Title>
-        <IconButton onClick={handleClose}>
+        <IconButton aria-label="친구 추가하기 모달 닫기" onClick={handleClose}>
           <Icon iconName="xMark" />
         </IconButton>
       </Header>

--- a/src/components/Modal/FriendSearchModal/index.tsx
+++ b/src/components/Modal/FriendSearchModal/index.tsx
@@ -59,7 +59,7 @@ const FriendSearchModal = ({ isOpen, onClose }: Props) => {
     >
       <Header>
         <Modal.Title>친구</Modal.Title>
-        <IconButton onClick={onClose}>
+        <IconButton aria-label="친구 모달 닫기" onClick={onClose}>
           <Icon iconName="xMark" />
         </IconButton>
       </Header>

--- a/src/components/Modal/GuideBook/index.tsx
+++ b/src/components/Modal/GuideBook/index.tsx
@@ -154,7 +154,11 @@ const GuideBook = ({ isOpen, onClose }: Props) => {
           )}
           <ButtonContainer>
             {currentGuide > MIN_GUIDE && (
-              <IconButton onClick={handlePrevGuide} disabled={currentGuide === MIN_GUIDE}>
+              <IconButton
+                aria-label="이전 가이드 보기"
+                onClick={handlePrevGuide}
+                disabled={currentGuide === MIN_GUIDE}
+              >
                 <Icon iconName="leftArrow" width={24} height={24} />
               </IconButton>
             )}
@@ -162,7 +166,11 @@ const GuideBook = ({ isOpen, onClose }: Props) => {
               {currentGuide === MAX_GUIDE ? 'start!' : '닫기'}
             </Button>
             {currentGuide < MAX_GUIDE && (
-              <IconButton onClick={handleNextGuide} disabled={currentGuide === MAX_GUIDE}>
+              <IconButton
+                aria-label="다음 가이드 보기"
+                onClick={handleNextGuide}
+                disabled={currentGuide === MAX_GUIDE}
+              >
                 <Icon iconName="rightArrow" width={24} height={24} />
               </IconButton>
             )}

--- a/src/components/Question/index.tsx
+++ b/src/components/Question/index.tsx
@@ -170,7 +170,11 @@ const Question = ({
           {!isEdited && (
             <ButtonsContainer>
               {isResumeWriterUser && (
-                <IconButton onClick={handleBookMarkClick} disabled={content === null}>
+                <IconButton
+                  aria-label={bookmarked ? '북마크 취소' : '북마크'}
+                  onClick={handleBookMarkClick}
+                  disabled={content === null}
+                >
                   {bookmarked ? (
                     <Icon
                       iconName="filledBookMark"
@@ -188,7 +192,11 @@ const Question = ({
                   )}
                 </IconButton>
               )}
-              <IconButton onClick={handleCheckMarkClick} disabled={content === null}>
+              <IconButton
+                aria-label={checked ? '체크 표시 취소' : '체크 표시'}
+                onClick={handleCheckMarkClick}
+                disabled={content === null}
+              >
                 {checked ? (
                   <Icon
                     iconName="filledCheckMark"
@@ -207,7 +215,11 @@ const Question = ({
               </IconButton>
               {isCommenterUser && (
                 <MoreIconContainer>
-                  <IconButton onClick={openDropdown} disabled={content === null}>
+                  <IconButton
+                    aria-label="예상질문 옵션 메뉴 열기"
+                    onClick={openDropdown}
+                    disabled={content === null}
+                  >
                     <Icon
                       iconName="more"
                       width={ICON_SIZE}

--- a/src/components/Reply/FeedbackReply/index.tsx
+++ b/src/components/Reply/FeedbackReply/index.tsx
@@ -114,7 +114,7 @@ const FeedbackReply = ({
 
         {!isEdited && isCommenterUser && (
           <MoreIconContainer>
-            <IconButton onClick={openDropdown}>
+            <IconButton aria-label="피드백 대댓글 옵션 메뉴 열기" onClick={openDropdown}>
               <Icon
                 iconName="more"
                 width={ICON_SIZE}

--- a/src/components/Reply/QuestionReply/index.tsx
+++ b/src/components/Reply/QuestionReply/index.tsx
@@ -114,7 +114,7 @@ const QuestionReply = ({
 
         {!isEdited && isCommenterUser && (
           <MoreIconContainer>
-            <IconButton onClick={openDropdown}>
+            <IconButton aria-label="예상질문 대댓글 옵션 메뉴 열기" onClick={openDropdown}>
               <Icon
                 iconName="more"
                 width={ICON_SIZE}

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -23,7 +23,7 @@ const Toast = () => {
   return createPortal(
     <ToastLayout $isOpen={!!toast} $type={toast.type}>
       {toast.message}
-      <IconButton onClick={closeToast}>
+      <IconButton aria-label="토스트 메세지 닫기" onClick={closeToast}>
         <Icon iconName="xMark" color={theme.color.neutral.text.weak} width={16} height={16} />
       </IconButton>
     </ToastLayout>,

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -70,6 +70,7 @@ const MyPage = () => {
           <Title>
             <span>내 친구</span>
             <IconButton
+              aria-label="친구 모달 열기"
               onClick={() => {
                 openFriendSearchModal();
                 manageBodyScroll(false);
@@ -105,6 +106,7 @@ const MyPage = () => {
           <Title>
             <span>전송한 친구 요청 보기</span>
             <IconButton
+              aria-label="전송한 친구 요청 보기 모달 열기"
               onClick={() => {
                 openFollowingModal();
                 manageBodyScroll(false);
@@ -142,6 +144,7 @@ const MyPage = () => {
           <Title>
             <span>친구 요청에 응답하기</span>
             <IconButton
+              aria-label="친구 요청에 응답하기 모달 열기"
               onClick={() => {
                 openFollowerModal();
                 manageBodyScroll(false);

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -221,7 +221,7 @@ const ResumeDetail = () => {
                   댓글
                 </Tab>
               </TabList>
-              <IconButton onClick={handleOpenGuideBook}>
+              <IconButton aria-label="가이드북 열기" onClick={handleOpenGuideBook}>
                 <Icon iconName="info" color={theme.palette.blue} width={24} height={24} />
               </IconButton>
             </ResumeDetailAsideHeader>

--- a/src/pages/ResumeUpdate/index.tsx
+++ b/src/pages/ResumeUpdate/index.tsx
@@ -25,7 +25,7 @@ const ResumeUpdate = () => {
 
   return (
     <PageMain>
-      <IconButton onClick={() => navigate(-1)}>
+      <IconButton aria-label="이전 페이지로 이동" onClick={() => navigate(-1)}>
         <Icon iconName="leftArrow" />
         <span>뒤로</span>
       </IconButton>

--- a/src/pages/ResumeUpload/index.tsx
+++ b/src/pages/ResumeUpload/index.tsx
@@ -11,7 +11,7 @@ const ResumeUpload = () => {
 
   return (
     <PageMain>
-      <IconButton onClick={() => navigate(-1)}>
+      <IconButton aria-label="이전 페이지로 이동" onClick={() => navigate(-1)}>
         <Icon iconName="leftArrow" />
         <span>뒤로</span>
       </IconButton>


### PR DESCRIPTION
## 개요

## 작업 사항

메인 페이지에서 `aria-label` 적용 이전 lighthouse 점수
<img width="841" alt="스크린샷 2024-04-19 오후 3 34 30" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/79e0629b-2be7-45f9-aadd-8d66c013cf42">

메인 페이지에서 `aria-label` 적용 이후 lighthouse 점수
<img width="772" alt="accessibility-button" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/3baece1e-b3ce-4df5-9f4a-dcc893adcb20">

## 이슈 번호

close #226 