### PR TITLE
[FE] 피드백의 카테고리를 선택하면 자동으로 submit되는 문제 해결

### DIFF
--- a/src/components/FeedbackForm/FeedbackAddForm/index.tsx
+++ b/src/components/FeedbackForm/FeedbackAddForm/index.tsx
@@ -65,6 +65,7 @@ const FeedbackAddForm = ({ resumeId, resumePage }: Props) => {
         {labelList?.map(({ id, label }) => {
           return (
             <Label
+              type="button"
               key={id}
               isActive={labelId === id}
               py="0.25rem"

--- a/src/components/FeedbackForm/FeedbackEditForm/index.tsx
+++ b/src/components/FeedbackForm/FeedbackEditForm/index.tsx
@@ -79,6 +79,7 @@ const FeedbackEditForm = ({
         {labelList?.map(({ id, label }) => {
           return (
             <Label
+              type="button"
               key={id}
               isActive={labelId === id}
               py="0.25rem"

--- a/src/components/FeedbackForm/FeedbackEditForm/index.tsx
+++ b/src/components/FeedbackForm/FeedbackEditForm/index.tsx
@@ -111,6 +111,7 @@ const FeedbackEditForm = ({
       />
       <ButtonWrapper $type="edit">
         <Button
+          type="button"
           variant="outline"
           size="s"
           onClick={(e) => {


### PR DESCRIPTION
## 개요

## 작업 사항

- 피드백 카테고리를 담당하는 Label 컴포넌트에 type을 `button`으로 설정
- 피드백 수정 버튼의 type을 `button`으로 설정

## 이슈 번호

close #228 
