### PR TITLE
[FE] 대댓글이 삭제했을 때 대댓글의 개수 업데이트 안되는 문제 해결

### DIFF
--- a/src/components/Reply/FeedbackReply/index.tsx
+++ b/src/components/Reply/FeedbackReply/index.tsx
@@ -95,7 +95,10 @@ const FeedbackReply = ({
       { resumeId, feedbackId: id, jwt },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: ['feedbackReplyList', resumeId, parentFeedbackId] });
+          return Promise.all([
+            queryClient.invalidateQueries({ queryKey: ['feedbackReplyList', resumeId, parentFeedbackId] }),
+            queryClient.invalidateQueries({ queryKey: ['feedbackList', resumeId] }),
+          ]);
         },
       },
     );

--- a/src/components/Reply/QuestionReply/index.tsx
+++ b/src/components/Reply/QuestionReply/index.tsx
@@ -95,7 +95,10 @@ const QuestionReply = ({
       { resumeId, questionId: id, jwt },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: ['questionReplyList', resumeId, parentQuestionId] });
+          return Promise.all([
+            queryClient.invalidateQueries({ queryKey: ['questionReplyList', resumeId, parentQuestionId] }),
+            queryClient.invalidateQueries({ queryKey: ['questionList', resumeId] }),
+          ]);
         },
       },
     );


### PR DESCRIPTION
## 개요

## 작업 사항

- 피드백 대댓글을 삭제할 경우, 피드백 목록을 재조회
- 예상질문 대댓글을 삭제할 경우, 예상질문 목록을 재조회

## 이슈 번호

close #235 