### PR TITLE
[FE] 메인페이지에서 사용하는 이미지들의 사이즈 스타일 변경

### DIFF
--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -16,7 +16,7 @@ import {
   Description,
   DescriptionText,
   Guide,
-  Img,
+  DescriptionImg,
   Main,
   MainImg,
   MainPageLayout,
@@ -58,7 +58,6 @@ const description: Description[] = [
 
 const MainPage = () => {
   const navigate = useNavigate();
-  const descriptionImgSizes = '(max-width: 600px) 90vw, (max-width: 768px) 300px, 416px';
 
   return (
     <MainPageLayout>
@@ -97,15 +96,15 @@ const MainPage = () => {
                 <DescriptionText>{description}</DescriptionText>
               </div>
               <picture>
-                <source type="image/webp" srcSet={imgSrcSet} sizes={descriptionImgSizes} />
-                <Img src={imgSrc} alt={id} />
+                <source type="image/webp" srcSet={imgSrcSet} />
+                <DescriptionImg src={imgSrc} alt={id} />
               </picture>
             </>
           ) : (
             <>
               <picture>
-                <source type="image/webp" srcSet={imgSrcSet} sizes={descriptionImgSizes} />
-                <Img src={imgSrc} alt={id} />
+                <source type="image/webp" srcSet={imgSrcSet} />
+                <DescriptionImg src={imgSrc} alt={id} />
               </picture>
               <div>
                 <Title>{title}</Title>

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -10,8 +10,19 @@ import mainLargeWebp from '@assets/main_1400w.webp';
 import questionJpg from '@assets/question.jpg';
 import questionWebp from '@assets/question_1000w.webp';
 import { Button } from 'review-me-design-system';
+import { screenSize } from '@styles/common';
 import { ROUTE_PATH } from '@constants';
-import { Description, DescriptionText, Guide, Img, Main, MainPageLayout, ReviewMe, Title } from './style';
+import {
+  Description,
+  DescriptionText,
+  Guide,
+  Img,
+  Main,
+  MainImg,
+  MainPageLayout,
+  ReviewMe,
+  Title,
+} from './style';
 
 interface Description {
   id: string;
@@ -47,7 +58,6 @@ const description: Description[] = [
 
 const MainPage = () => {
   const navigate = useNavigate();
-  const mainImgBreakPoint = '(max-width: 768px)';
   const descriptionImgSizes = '(max-width: 600px) 90vw, (max-width: 768px) 300px, 416px';
 
   return (
@@ -61,10 +71,15 @@ const MainPage = () => {
         <picture>
           <source
             type="image/webp"
-            srcSet={`${mainSmallWebp} 1040w, ${mainLargeWebp} 1680w`}
-            sizes={`${mainImgBreakPoint} 90vw, 700px`}
+            media={`(max-width: ${screenSize.smallTablet}px)`}
+            srcSet={mainSmallWebp}
           />
-          <Img src={mainJpg} alt="main" />
+          <source
+            type="image/webp"
+            media={`(min-width: ${screenSize.smallTablet + 1}px)`}
+            srcSet={mainLargeWebp}
+          />
+          <MainImg src={mainJpg} alt="main" />
         </picture>
       </Main>
 

--- a/src/pages/MainPage/style.ts
+++ b/src/pages/MainPage/style.ts
@@ -27,7 +27,7 @@ const Main = styled.section`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 1rem;
+  gap: 2rem;
   margin-top: 4rem;
 `;
 

--- a/src/pages/MainPage/style.ts
+++ b/src/pages/MainPage/style.ts
@@ -1,5 +1,5 @@
 import { theme } from 'review-me-design-system';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { breakPoints } from '@styles/common';
 
 const MainPageLayout = styled.main`
@@ -40,9 +40,19 @@ const ReviewMe = styled.span`
   color: ${theme.color.accent.text.weak};
 `;
 
-const Img = styled.img`
+const imageStyles = css`
   border-radius: 1.25rem;
   box-shadow: 0.875rem 1.75rem 2.5rem rgba(0, 0, 0, 0.05);
+`;
+
+const MainImg = styled.img`
+  ${imageStyles}
+  width: 100%;
+  max-width: 700px;
+`;
+
+const Img = styled.img`
+  ${imageStyles}
 `;
 
 const Guide = styled.div`
@@ -75,4 +85,4 @@ const DescriptionText = styled.span`
   color: ${theme.palette.gray500};
 `;
 
-export { MainPageLayout, Main, Title, ReviewMe, Img, Guide, Description, DescriptionText };
+export { MainPageLayout, Main, Title, ReviewMe, MainImg, Img, Guide, Description, DescriptionText };

--- a/src/pages/MainPage/style.ts
+++ b/src/pages/MainPage/style.ts
@@ -51,8 +51,14 @@ const MainImg = styled.img`
   max-width: 700px;
 `;
 
-const Img = styled.img`
+const DescriptionImg = styled.img`
   ${imageStyles}
+  width: 100%;
+  max-width: 416px;
+
+  @media ${breakPoints.mobile} {
+    max-width: 100%;
+  }
 `;
 
 const Guide = styled.div`
@@ -85,4 +91,14 @@ const DescriptionText = styled.span`
   color: ${theme.palette.gray500};
 `;
 
-export { MainPageLayout, Main, Title, ReviewMe, MainImg, Img, Guide, Description, DescriptionText };
+export {
+  MainPageLayout,
+  Main,
+  Title,
+  ReviewMe,
+  MainImg,
+  DescriptionImg,
+  Guide,
+  Description,
+  DescriptionText,
+};

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -8,10 +8,18 @@ export const ellipsisStyles = css`
   word-break: break-all;
 `;
 
+export const screenSize = {
+  mobile: 600,
+  smallTablet: 768,
+  tablet: 1199,
+  desktop: 1200,
+};
+
 export const breakPoints = {
-  mobile: 'screen and (max-width: 600px)',
-  tablet: 'screen and (max-width: 1199px)',
-  desktop: 'screen and (min-width: 1200px)',
+  mobile: `screen and (max-width: ${screenSize.mobile}px)`,
+  smallTablet: `screen and (max-width: ${screenSize.smallTablet}px)`,
+  tablet: `screen and (max-width: ${screenSize.tablet}px)`,
+  desktop: `screen and (min-width: ${screenSize.desktop}px)`,
 };
 
 export const PageMain = styled.main<{ $css?: CSSProp }>`


### PR DESCRIPTION
## 개요

## 작업 사항

메인 이미지
- 가로 사이즈: 100%
- 최대 가로 사이즈: 700px

피드백, 예상질문, 댓글 이미지
- 가로 사이즈: 100%
- 최대 가로 사이즈
  - 모바일: 100%
  - 모바일 이외: 416px

## 이슈 번호

close #230 