### PR TITLE
[FE] 이력서 메인 페이지에서 사용하는 컴포넌트 스타일 수정 

### DIFF
--- a/src/pages/Resume/style.ts
+++ b/src/pages/Resume/style.ts
@@ -10,7 +10,7 @@ const MainHeader = styled.header`
 
   @media ${breakPoints.mobile} {
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 1rem;
     align-items: start;
   }
 `;

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -37,7 +37,7 @@ export const PageMain = styled.main<{ $css?: CSSProp }>`
   }
   @media ${breakPoints.mobile} {
     width: 90%;
-    margin: 0.5rem auto;
+    margin: 1rem auto;
   }
 
   ${({ $css }) => $css}


### PR DESCRIPTION
## 개요

## 작업 사항

- 이력서 메인 페이지의 Header 스타일 변경
- 공통 main 컴포넌트 스타일 변경

스타일 변경 전

<img width="414" alt="스크린샷 2024-05-11 오후 3 35 11" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/d00fdfa1-6de2-4a55-9c71-bd042f1eb28b">

스타일 변경 후

<img width="413" alt="스크린샷 2024-05-11 오후 3 36 00" src="https://github.com/review-me-Team/review-me-fe/assets/96980857/641594e9-82b2-457b-bac8-4ecd2aa68df5">

## 이슈 번호

close #250 

