### PR TITLE
[FE] refresh token으로 access token을 재발급 받을 때 context 값이 갱신되지 않는 문제 해결

### DIFF
--- a/src/components/TokenRefresh/index.tsx
+++ b/src/components/TokenRefresh/index.tsx
@@ -11,12 +11,17 @@ interface Props {
 
 const TokenRefresh = ({ children }: Props) => {
   const { data, status, error, isFetched } = useRenewJwt();
-  const { login, logout, isLoggedIn } = useUserContext();
+  const { jwt, login, logout, isLoggedIn } = useUserContext();
   const { openToast } = useToastContext();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (isLoggedIn) return;
+    if (isLoggedIn) {
+      const isRenewedJwt = data && jwt !== data.jwt;
+
+      if (isRenewedJwt) login(data.jwt);
+      return;
+    }
 
     if (status === 'success' && data) {
       login(data.jwt);
@@ -28,7 +33,7 @@ const TokenRefresh = ({ children }: Props) => {
         navigate(ROUTE_PATH.ROOT);
       }
     }
-  }, [isFetched, isLoggedIn, data, status, error]);
+  }, [isFetched, isLoggedIn, data, status, error, jwt]);
 
   if (status === 'pending') return <></>;
 


### PR DESCRIPTION
## 개요

10분마다 주기적으로 refresh token을 이용해 access token을 재발급 받는다. 그러나 context로 관리되는 access token이 재발급된 토큰 값으로 갱신이 안되는 문제가 발생했다.
따라서 다음과 같이 로직을 생각해봤다.

1. 로그인 된 상태에서 10분마다 refresh token으로 access token을 재발급 받는다.
2. 로그인 된 상태이지만 기존 context에 저장되어있는 토큰 값과 재발급 받은 access token의 값이 다르면, 다시 로그인을 시도한다.

## 작업 사항

## 이슈 번호

close #254 
