### PR TITLE
[FE] 이력서 pdf에 나타났던 로딩 텍스트 제거

### DIFF
--- a/src/components/PdfViewer/index.tsx
+++ b/src/components/PdfViewer/index.tsx
@@ -43,6 +43,7 @@ const PdfViewer = ({
           <Document
             file={typeof file === 'string' ? `${process.env.BASE_PDF_URL}/${file}` : file}
             onLoadSuccess={({ numPages }) => onLoadSuccess(numPages)}
+            loading={null}
           >
             {showAllPages ? (
               Array.from(new Array(totalPages), (el, index) => (
@@ -52,10 +53,17 @@ const PdfViewer = ({
                   scale={scale}
                   renderAnnotationLayer={true}
                   renderTextLayer={false}
+                  loading={null}
                 />
               ))
             ) : (
-              <Page pageNumber={pageNum} scale={scale} renderAnnotationLayer={true} renderTextLayer={false} />
+              <Page
+                pageNumber={pageNum}
+                scale={scale}
+                renderAnnotationLayer={true}
+                renderTextLayer={false}
+                loading={null}
+              />
             )}
           </Document>
         </DocumentWrapper>


### PR DESCRIPTION
## 개요

이력서 상세 페이지에 접속했을 때 pdf가 보여야 하는 곳에 `loading...` 텍스트가 뜨는 현상이 있었다.

https://github.com/user-attachments/assets/04e0d1d8-2350-4ada-8962-a5b93d3a13d3

## 작업 사항

react-pdf 라이브러리 공식문서를 보니 기본으로 설정되어 있던 스타일이었다.
loading props에 null 값을 주어 loading 표시를 지웠다.

