### PR TITLE
[FE] modal 로직 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -144,18 +144,20 @@ const Header = () => {
                 <MenuItem>
                   <Link to={ROUTE_PATH.RESUME}>이력서</Link>
                 </MenuItem>
-                <MenuItem
-                  onClick={() => {
-                    if (!isLoggedIn) {
-                      const loginRequestModalId = open(LoginRequestModal, {
-                        onClose: () => close(loginRequestModalId),
-                      });
-                      return;
-                    }
-                    navigate(ROUTE_PATH.MY_RESUME);
-                  }}
-                >
-                  My 이력서
+                <MenuItem>
+                  <button
+                    onClick={() => {
+                      if (!isLoggedIn) {
+                        const loginRequestModalId = open(LoginRequestModal, {
+                          onClose: () => close(loginRequestModalId),
+                        });
+                        return;
+                      }
+                      navigate(ROUTE_PATH.MY_RESUME);
+                    }}
+                  >
+                    My 이력서
+                  </button>
                 </MenuItem>
               </MenuList>
             </LeftContainer>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -31,7 +31,7 @@ const Header = () => {
   const { matches: isMobile } = useMediaQuery({ mediaQueryString: breakPoints.mobile });
   const { isLoggedIn, logout } = useUserContext();
 
-  const { open, close } = useModals();
+  const { open } = useModals();
   const [isOpenMobileMenu, setIsOpenMobileMenu] = useState<boolean>(false);
 
   const handleOpenMobileMenu = () => {
@@ -148,9 +148,9 @@ const Header = () => {
                   <button
                     onClick={() => {
                       if (!isLoggedIn) {
-                        const loginRequestModalId = open(LoginRequestModal, {
-                          onClose: () => close(loginRequestModalId),
-                        });
+                        open(({ isOpen, onClose }) => (
+                          <LoginRequestModal isOpen={isOpen} onClose={onClose} />
+                        ));
                         return;
                       }
                       navigate(ROUTE_PATH.MY_RESUME);
@@ -168,9 +168,7 @@ const Header = () => {
               aria-label="마이페이지로 이동"
               onClick={() => {
                 if (!isLoggedIn) {
-                  const loginRequestModalId = open(LoginRequestModal, {
-                    onClose: () => close(loginRequestModalId),
-                  });
+                  open(({ isOpen, onClose }) => <LoginRequestModal isOpen={isOpen} onClose={onClose} />);
                   return;
                 }
                 navigate(ROUTE_PATH.MY_PAGE);

--- a/src/components/MyResumeItem/index.tsx
+++ b/src/components/MyResumeItem/index.tsx
@@ -25,7 +25,7 @@ interface Props {
 }
 
 const MyResumeItem = ({ id, title, year, occupation, scope, createdAt }: Props) => {
-  const { open, close } = useModals();
+  const { open } = useModals();
   const navigate = useNavigate();
 
   return (
@@ -51,10 +51,9 @@ const MyResumeItem = ({ id, title, year, occupation, scope, createdAt }: Props) 
         <Button
           $position="right"
           onClick={() => {
-            const resumeDeleteModalId = open(ResumeDeleteModal, {
-              resumeId: id,
-              onClose: () => close(resumeDeleteModalId),
-            });
+            open(({ isOpen, onClose }) => (
+              <ResumeDeleteModal resumeId={id} isOpen={isOpen} onClose={onClose} />
+            ));
           }}
         >
           삭제

--- a/src/components/UserItem/index.tsx
+++ b/src/components/UserItem/index.tsx
@@ -25,7 +25,7 @@ const UserItem = ({ type: initType, userId, userImg, userName }: Props) => {
 
   const [type, setType] = useState<Type>(initType);
 
-  const { open, close } = useModals();
+  const { open } = useModals();
 
   const { mutate: requestFriend } = usePostFriendRequest();
   const { mutate: cancelFriendRequest } = useDeleteFriendRequest();
@@ -57,10 +57,9 @@ const UserItem = ({ type: initType, userId, userImg, userName }: Props) => {
             variant="outline"
             size="s"
             onClick={() => {
-              const friendDeleteModalId = open(FriendDeleteModal, {
-                friendId: userId,
-                onClose: () => close(friendDeleteModalId),
-              });
+              open(({ isOpen, onClose }) => (
+                <FriendDeleteModal friendId={userId} isOpen={isOpen} onClose={onClose} />
+              ));
             }}
           >
             삭제

--- a/src/contexts/modalContext.tsx
+++ b/src/contexts/modalContext.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, FunctionComponent, ReactNode, createContext, useContext } from 'react';
+import React, { ReactNode, createContext, useContext, useEffect } from 'react';
 import { manageBodyScroll } from '@utils';
 
 type ModalIdType = string;
@@ -63,6 +63,17 @@ const ModalProvider = ({ children }: ModalProviderProps) => {
       manageBodyScroll(true);
     }
   };
+
+  const removeAll = () => {
+    setModalList([]);
+    manageBodyScroll(true);
+  };
+
+  useEffect(() => {
+    return () => {
+      removeAll();
+    };
+  }, []);
 
   return (
     <ModalContext.Provider value={{ push, pop }}>

--- a/src/contexts/modalContext.tsx
+++ b/src/contexts/modalContext.tsx
@@ -1,17 +1,22 @@
 import React, { ComponentProps, FunctionComponent, ReactNode, createContext, useContext } from 'react';
+import { manageBodyScroll } from '@utils';
 
 type ModalIdType = string;
 
+type ModalComponentFunctionType = (params: { isOpen: boolean; onClose: () => void }) => JSX.Element;
+
 interface ModalType {
-  Component: FunctionComponent<any>;
-  props: ComponentProps<FunctionComponent<any>>;
   id: ModalIdType;
+  isOpen: boolean;
+  modalComponent: ModalComponentFunctionType;
 }
 
+type PushType = ({ modalComponent, id }: Omit<ModalType, 'isOpen'>) => void;
+type PopType = (id: ModalIdType) => void;
+
 interface ModalContext {
-  modals: ModalType[];
-  push: ({ Component, props, id }: ModalType) => void;
-  pop: (id: string) => void;
+  push: PushType;
+  pop: PopType;
 }
 
 const ModalContext = createContext<ModalContext | null>(null);
@@ -26,34 +31,44 @@ export const useModalContext = () => {
   return context;
 };
 
+const ModalController = ({
+  isOpen,
+  modalController: ModalComponent,
+  unmount,
+}: {
+  isOpen: boolean;
+  modalController: ModalComponentFunctionType;
+  unmount: () => void;
+}) => {
+  return <ModalComponent isOpen={isOpen} onClose={unmount} />;
+};
+
 interface ModalProviderProps {
   children: ReactNode;
 }
 
 const ModalProvider = ({ children }: ModalProviderProps) => {
-  const [Modals, setModals] = React.useState<ModalType[]>([]);
+  const [modalList, setModalList] = React.useState<ModalType[]>([]);
 
-  const push = ({ Component, props, id }: ModalType) => {
-    document.body.style.overflow = 'hidden';
+  const push: PushType = ({ modalComponent, id }) => {
+    manageBodyScroll(false);
 
-    setModals((prev) => [...prev, { Component, props: { ...props, isOpen: true }, id }]);
+    setModalList((prev) => [...prev, { modalComponent, id, isOpen: true }]);
   };
 
-  const pop = (id: ModalIdType) => {
-    const hasModal = Modals.length > 0;
+  const pop: PopType = (id) => {
+    setModalList((prev) => prev.filter((C) => C.id !== id));
 
-    if (!hasModal) {
-      document.body.style.overflow = 'auto';
+    if (modalList.length === 1) {
+      manageBodyScroll(true);
     }
-
-    setModals((prev) => prev.filter((C) => C.id !== id));
   };
 
   return (
-    <ModalContext.Provider value={{ modals: Modals, push, pop }}>
+    <ModalContext.Provider value={{ push, pop }}>
       {children}
-      {Modals.map(({ Component, props, id }) => (
-        <Component key={id} {...props} />
+      {modalList.map(({ id, modalComponent, isOpen }) => (
+        <ModalController key={id} isOpen={isOpen} modalController={modalComponent} unmount={() => pop(id)} />
       ))}
     </ModalContext.Provider>
   );

--- a/src/contexts/modalContext.tsx
+++ b/src/contexts/modalContext.tsx
@@ -1,9 +1,6 @@
 import React, { ReactNode, createContext, useContext, useEffect } from 'react';
+import { ModalComponentFunctionType, ModalIdType } from '@customTypes/modal';
 import { manageBodyScroll } from '@utils';
-
-type ModalIdType = string;
-
-type ModalComponentFunctionType = (params: { isOpen: boolean; onClose: () => void }) => JSX.Element;
 
 interface ModalType {
   id: ModalIdType;

--- a/src/contexts/modalContext.tsx
+++ b/src/contexts/modalContext.tsx
@@ -50,10 +50,13 @@ interface ModalProviderProps {
 const ModalProvider = ({ children }: ModalProviderProps) => {
   const [modalList, setModalList] = React.useState<ModalType[]>([]);
 
-  const push: PushType = ({ modalComponent, id }) => {
+  const push: PushType = ({ modalComponent, id: newModalId }) => {
     manageBodyScroll(false);
 
-    setModalList((prev) => [...prev, { modalComponent, id, isOpen: true }]);
+    setModalList((prev) => [
+      ...prev.filter(({ id }) => id !== newModalId),
+      { modalComponent, id: newModalId, isOpen: true },
+    ]);
   };
 
   const pop: PopType = (id) => {

--- a/src/hooks/useModals.ts
+++ b/src/hooks/useModals.ts
@@ -1,22 +1,17 @@
-import { ComponentProps, FunctionComponent } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useModalContext } from '@contexts/modalContext';
 
+type ModalComponentFunctionType = (params: { isOpen: boolean; onClose: () => void }) => JSX.Element;
+
 const useModals = () => {
-  const { push, pop } = useModalContext();
+  const { push } = useModalContext();
 
-  const open = (Component: FunctionComponent<any>, props: ComponentProps<FunctionComponent<any>> = {}) => {
+  const open = (modalComponent: ModalComponentFunctionType) => {
     const id = uuidv4();
-    push({ Component, props, id });
-
-    return id;
+    push({ id, modalComponent });
   };
 
-  const close = (id: string) => {
-    pop(id);
-  };
-
-  return { open, close };
+  return { open };
 };
 
 export default useModals;

--- a/src/hooks/useModals.ts
+++ b/src/hooks/useModals.ts
@@ -2,12 +2,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { useModalContext } from '@contexts/modalContext';
 
 type ModalComponentFunctionType = (params: { isOpen: boolean; onClose: () => void }) => JSX.Element;
+type ModalOptions = { modalId: string };
 
 const useModals = () => {
   const { push } = useModalContext();
 
-  const open = (modalComponent: ModalComponentFunctionType) => {
-    const id = uuidv4();
+  const open = (modalComponent: ModalComponentFunctionType, options?: ModalOptions) => {
+    const id = options?.modalId ?? uuidv4();
+
     push({ id, modalComponent });
   };
 

--- a/src/hooks/useModals.ts
+++ b/src/hooks/useModals.ts
@@ -1,8 +1,8 @@
+import { ModalComponentFunctionType, ModalIdType } from '@customTypes/modal';
 import { v4 as uuidv4 } from 'uuid';
 import { useModalContext } from '@contexts/modalContext';
 
-type ModalComponentFunctionType = (params: { isOpen: boolean; onClose: () => void }) => JSX.Element;
-type ModalOptions = { modalId: string };
+type ModalOptions = { modalId: ModalIdType };
 
 const useModals = () => {
   const { push } = useModalContext();

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -22,7 +22,7 @@ const MyPage = () => {
 
   const ITEM_COUNT = 2;
 
-  const { open, close } = useModals();
+  const { open } = useModals();
 
   return (
     <PageMain
@@ -39,14 +39,17 @@ const MyPage = () => {
         variant="default"
         size="l"
         onClick={() => {
-          const friendRequestModalId = open(FriendRequestModal, {
-            onClose: () => {
-              refetchFriendList();
-              refetchFollowingList();
-              refetchFollowerList();
-              close(friendRequestModalId);
-            },
-          });
+          open(({ isOpen, onClose }) => (
+            <FriendRequestModal
+              isOpen={isOpen}
+              onClose={() => {
+                refetchFriendList();
+                refetchFollowingList();
+                refetchFollowerList();
+                onClose();
+              }}
+            />
+          ));
         }}
       >
         친구 추가하기
@@ -59,9 +62,7 @@ const MyPage = () => {
             <IconButton
               aria-label="친구 모달 열기"
               onClick={() => {
-                const friendSearchModalId = open(FriendSearchModal, {
-                  onClose: () => close(friendSearchModalId),
-                });
+                open(({ isOpen, onClose }) => <FriendSearchModal isOpen={isOpen} onClose={onClose} />);
               }}
             >
               <Icon iconName="rightArrow" />
@@ -89,12 +90,15 @@ const MyPage = () => {
             <IconButton
               aria-label="전송한 친구 요청 보기 모달 열기"
               onClick={() => {
-                const followingModalId = open(FollowingModal, {
-                  onClose: () => {
-                    refetchFollowingList();
-                    close(followingModalId);
-                  },
-                });
+                open(({ isOpen, onClose }) => (
+                  <FollowingModal
+                    isOpen={isOpen}
+                    onClose={() => {
+                      refetchFriendList();
+                      onClose();
+                    }}
+                  />
+                ));
 
                 refetchFollowingList();
               }}
@@ -124,13 +128,16 @@ const MyPage = () => {
             <IconButton
               aria-label="친구 요청에 응답하기 모달 열기"
               onClick={() => {
-                const followerModalId = open(FollowerModal, {
-                  onClose: () => {
-                    refetchFollowerList();
-                    refetchFriendList();
-                    close(followerModalId);
-                  },
-                });
+                open(({ isOpen, onClose }) => (
+                  <FollowerModal
+                    isOpen={isOpen}
+                    onClose={() => {
+                      refetchFollowerList();
+                      refetchFriendList();
+                      onClose();
+                    }}
+                  />
+                ));
               }}
             >
               <Icon iconName="rightArrow" />

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -131,14 +131,16 @@ const ResumeDetail = () => {
 
   const isMyResume = resumeDetail.writerId === user?.id;
 
+  const SKIP_GUIDE_BOOK_KEY = 'skipGuideBook';
+
   useEffect(() => {
-    if (!localStorage.getItem('skipGuideBook')) {
+    if (!localStorage.getItem(SKIP_GUIDE_BOOK_KEY)) {
       open(
         ({ isOpen, onClose }) => (
           <GuideBook
             isOpen={isOpen}
             onClose={() => {
-              localStorage.setItem('skipGuideBook', 'true');
+              localStorage.setItem(SKIP_GUIDE_BOOK_KEY, 'true');
               onClose();
             }}
           />
@@ -233,7 +235,7 @@ const ResumeDetail = () => {
                   <GuideBook
                     isOpen={isOpen}
                     onClose={() => {
-                      localStorage.setItem('skipGuideBook', 'true');
+                      localStorage.setItem(SKIP_GUIDE_BOOK_KEY, 'true');
                       onClose();
                     }}
                   />

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -123,7 +123,7 @@ const ResumeDetail = () => {
 
   const hasViewedGuideBook = localStorage.getItem('skip') === 'true';
 
-  const { open, close } = useModals();
+  const { open } = useModals();
 
   const commentListRef = useRef<HTMLUListElement>(null);
 
@@ -135,12 +135,15 @@ const ResumeDetail = () => {
 
   useEffect(() => {
     if (!hasViewedGuideBook) {
-      const guideBookModalId = open(GuideBook, {
-        onClose: () => {
-          localStorage.setItem('skip', 'true');
-          close(guideBookModalId);
-        },
-      });
+      open(({ isOpen, onClose }) => (
+        <GuideBook
+          isOpen={isOpen}
+          onClose={() => {
+            localStorage.setItem('skip', 'true');
+            onClose();
+          }}
+        />
+      ));
     }
   }, [hasViewedGuideBook]);
 
@@ -223,12 +226,15 @@ const ResumeDetail = () => {
             <IconButton
               aria-label="가이드북 열기"
               onClick={() => {
-                const guideBookModalId = open(GuideBook, {
-                  onClose: () => {
-                    localStorage.setItem('skip', 'true');
-                    close(guideBookModalId);
-                  },
-                });
+                open(({ isOpen, onClose }) => (
+                  <GuideBook
+                    isOpen={isOpen}
+                    onClose={() => {
+                      localStorage.setItem('skip', 'true');
+                      onClose();
+                    }}
+                  />
+                ));
               }}
             >
               <Icon iconName="info" color={theme.palette.blue} width={24} height={24} />

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -121,8 +121,6 @@ const ResumeDetail = () => {
     setFilter({ checked: false, bookmarked: false });
   };
 
-  const hasViewedGuideBook = localStorage.getItem('skip') === 'true';
-
   const { open } = useModals();
 
   const commentListRef = useRef<HTMLUListElement>(null);
@@ -134,18 +132,23 @@ const ResumeDetail = () => {
   const isMyResume = resumeDetail.writerId === user?.id;
 
   useEffect(() => {
-    if (!hasViewedGuideBook) {
-      open(({ isOpen, onClose }) => (
-        <GuideBook
-          isOpen={isOpen}
-          onClose={() => {
-            localStorage.setItem('skip', 'true');
-            onClose();
-          }}
-        />
-      ));
+    if (!localStorage.getItem('skipGuideBook')) {
+      open(
+        ({ isOpen, onClose }) => (
+          <GuideBook
+            isOpen={isOpen}
+            onClose={() => {
+              localStorage.setItem('skipGuideBook', 'true');
+              onClose();
+            }}
+          />
+        ),
+        {
+          modalId: 'guideBook',
+        },
+      );
     }
-  }, [hasViewedGuideBook]);
+  }, []);
 
   return (
     <Main>
@@ -230,7 +233,7 @@ const ResumeDetail = () => {
                   <GuideBook
                     isOpen={isOpen}
                     onClose={() => {
-                      localStorage.setItem('skip', 'true');
+                      localStorage.setItem('skipGuideBook', 'true');
                       onClose();
                     }}
                   />

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -1,0 +1,3 @@
+export type ModalIdType = string;
+
+export type ModalComponentFunctionType = (params: { isOpen: boolean; onClose: () => void }) => JSX.Element;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
       "@utils/*": ["./utils/*"],
       "@constants": ["./constants/index.ts"],
       "@constants/*": ["./constants/*"],
-      "@apis/*": ["./apis/*"]
+      "@apis/*": ["./apis/*"],
+      "@customTypes/*": ["./types/*"]
     }
   },
   "include": ["src/**/*", "./declaration.d.ts"],

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,6 +27,7 @@ module.exports = {
       '@utils': path.resolve(__dirname, 'src/utils'),
       '@constants': path.resolve(__dirname, 'src/constants'),
       '@apis': path.resolve(__dirname, 'src/apis'),
+      '@customTypes': path.resolve(__dirname, 'src/types'),
     },
   },
   module: {


### PR DESCRIPTION
## 개요

## 작업 사항

바꾸기 전에는 open 함수가 반환하는 값을 다시 open의 인수에서 사용됐다. 지금보니 이 코드가 이상해보이고, 한 눈에 들어오지 않는다.
```tsx
const loginRequestModalId = open(LoginRequestModal, {
  onClose: () => close(loginRequestModalId),
});
```

바꾼 후에는 모달 컴포넌트에 isOpen과 onClose 값만 넘겨주면 된다. 
```tsx
open(({ isOpen, onClose }) => (
  <LoginRequestModal isOpen={isOpen} onClose={onClose} />
));
```

그리고 open의 두 번째 파라미터로 modal의 id 값을 직접 설정할 수 있다. 하지만, 다른 모달의 id 값과 중복되지 않도록 조심해야 한다.

```tsx
open(
        ({ isOpen, onClose }) => (
          <GuideBook
            isOpen={isOpen}
            onClose={() => {
              localStorage.setItem('skipGuideBook', 'true');
              onClose();
            }}
          />
        ),
        {
          modalId: 'guideBook',
        },
);
```

## 이슈 번호
