### PR TITLE
[FE] 피드백, 예상질문, 댓글 각 탭이 활성화 될 때 보여줄 UI를 컴포넌트로 분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "review-me",
       "dependencies": {
-        "@tanstack/react-query": "^5.8.4",
-        "@tanstack/react-query-devtools": "^5.17.21",
+        "@tanstack/react-query": "^5.67.2",
+        "@tanstack/react-query-devtools": "^5.67.2",
         "dotenv": "^16.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -7809,52 +7809,56 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.17.19",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.17.19.tgz",
-      "integrity": "sha512-Lzw8FUtnLCc9Jwz0sw9xOjZB+/mCCmJev38v2wHMUl/ioXNIhnNWeMxu0NKUjIhAd62IRB3eAtvxAGDJ55UkyA==",
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.2.tgz",
+      "integrity": "sha512-+iaFJ/pt8TaApCk6LuZ0WHS/ECVfTzrxDOEL9HH9Dayyb5OVuomLzDXeSaI2GlGT/8HN7bDGiRXDts3LV+u6ww==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.17.21",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.17.21.tgz",
-      "integrity": "sha512-WWfcnNjTEqcuAS5GyKkVGkseuES6yd197MJWGImBu+MoCjWPqxSXKCCfm+utSXJauJUGm7xoMmhqCphiQdjf8w==",
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.67.2.tgz",
+      "integrity": "sha512-O4QXFFd7xqp6EX7sdvc9tsVO8nm4lpWBqwpgjpVLW5g7IeOY6VnS/xvs/YzbRhBVkKTMaJMOUGU7NhSX+YGoNg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.17.19",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.17.19.tgz",
-      "integrity": "sha512-qaQENB6/03Gj3dFZGvdmUoqeUGlGm7P1p0RmaR04Bf1Ib1T9lLGimcC9T3oCFbrx0b2ZF21ngjFZNjj9uPJMcg==",
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.2.tgz",
+      "integrity": "sha512-6Sa+BVNJWhAV4QHvIqM73norNeGRWGC3ftN0Ix87cmMvI215I1wyJ44KUTt/9a0V9YimfGcg25AITaYVel71Og==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.17.19"
+        "@tanstack/query-core": "5.67.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.17.21",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.17.21.tgz",
-      "integrity": "sha512-Ri1AuWpN67eyPdMTlPxx1TMGNUaxTHrGv0ll0S20ZObz/Xms5wfANV3c6OX0HZTY0igudP1k5jpRLXNkd249mg==",
+      "version": "5.67.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.67.2.tgz",
+      "integrity": "sha512-cmj2DxBc+/9btQ66n5xI8wTtAma2BLVa403K7zIYiguzJ/kV201jnGensYqJeu1Rd8uRMLLRM74jLVMLDWNRJA==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.17.21"
+        "@tanstack/query-devtools": "5.67.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.17.19",
-        "react": "^18.0.0"
+        "@tanstack/react-query": "^5.67.2",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "review-me",
   "main": "./src/index.tsx",
   "dependencies": {
-    "@tanstack/react-query": "^5.8.4",
-    "@tanstack/react-query-devtools": "^5.17.21",
+    "@tanstack/react-query": "^5.67.2",
+    "@tanstack/react-query-devtools": "^5.67.2",
     "dotenv": "^16.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/apis/commentApi.ts
+++ b/src/apis/commentApi.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { useMutation, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { REQUEST_URL } from '@constants';
 import { apiClient } from './apiClient';
 import { PageNationData } from './response.types';
@@ -51,12 +51,11 @@ export const getCommentList = async ({
 
 interface UseCommentListProps {
   resumeId: number;
-  enabled: boolean;
   jwt?: string;
 }
 
-export const useCommentList = ({ resumeId, enabled, jwt }: UseCommentListProps) => {
-  return useInfiniteQuery({
+export const useCommentList = ({ resumeId, jwt }: UseCommentListProps) => {
+  return useSuspenseInfiniteQuery({
     queryKey: ['commentList', resumeId],
     initialPageParam: 0,
     queryFn: ({ pageParam }) => getCommentList({ resumeId, pageParam, jwt }),
@@ -66,7 +65,6 @@ export const useCommentList = ({ resumeId, enabled, jwt }: UseCommentListProps) 
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
     select: (data) => data.pages.flatMap((page) => page.comments),
-    enabled,
   });
 };
 

--- a/src/apis/feedbackApi.ts
+++ b/src/apis/feedbackApi.ts
@@ -1,4 +1,9 @@
-import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query';
 import { REPLY_LIST_SIZE, REQUEST_URL } from '@constants';
 import { apiClient } from './apiClient';
 import { PageNationData } from './response.types';
@@ -64,12 +69,11 @@ interface UseFeedbackListProps {
   resumeId: number;
   resumePage: number;
   checked: boolean;
-  enabled: boolean;
   jwt?: string;
 }
 
-export const useFeedbackList = ({ resumeId, resumePage, checked, enabled, jwt }: UseFeedbackListProps) => {
-  return useInfiniteQuery({
+export const useFeedbackList = ({ resumeId, resumePage, checked, jwt }: UseFeedbackListProps) => {
+  return useSuspenseInfiniteQuery({
     queryKey: ['feedbackList', resumeId, resumePage, checked],
     initialPageParam: 0,
     queryFn: ({ pageParam }) => getFeedbackList({ resumeId, pageParam, resumePage, checked, jwt }),
@@ -79,7 +83,6 @@ export const useFeedbackList = ({ resumeId, resumePage, checked, enabled, jwt }:
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
     select: (data) => data.pages.flatMap((page) => page.feedbacks),
-    enabled,
   });
 };
 

--- a/src/apis/questionApi.ts
+++ b/src/apis/questionApi.ts
@@ -1,4 +1,9 @@
-import { InfiniteData, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query';
 import { REPLY_LIST_SIZE, REQUEST_URL } from '@constants';
 import { apiClient } from './apiClient';
 import { PageNationData } from './response.types';
@@ -70,19 +75,11 @@ interface UseQuestionListProps {
   resumePage: number;
   checked: boolean;
   bookmarked: boolean;
-  enabled: boolean;
   jwt?: string;
 }
 
-export const useQuestionList = ({
-  resumeId,
-  resumePage,
-  checked,
-  bookmarked,
-  enabled,
-  jwt,
-}: UseQuestionListProps) => {
-  return useInfiniteQuery({
+export const useQuestionList = ({ resumeId, resumePage, checked, bookmarked, jwt }: UseQuestionListProps) => {
+  return useSuspenseInfiniteQuery({
     queryKey: ['questionList', resumeId, resumePage, checked, bookmarked],
     initialPageParam: 0,
     queryFn: ({ pageParam }) =>
@@ -93,7 +90,6 @@ export const useQuestionList = ({
       return pageNumber < lastPageNum ? pageNumber + 1 : null;
     },
     select: (data) => data.pages.flatMap((page) => page.questions),
-    enabled,
   });
 };
 

--- a/src/apis/resumeApi.ts
+++ b/src/apis/resumeApi.ts
@@ -125,7 +125,7 @@ export const useMyResumeList = ({ jwt }: UseMyResumeListProps) => {
 };
 
 // GET 이력서 상세 조회
-interface GetResumeDetail {
+export interface GetResumeDetail {
   resumeUrl: string;
   title: string;
   writerId: number;

--- a/src/hooks/useGuideBook.tsx
+++ b/src/hooks/useGuideBook.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+import GuideBook from '@components/Modal/GuideBook';
+import useModals from './useModals';
+
+const useGuideBook = () => {
+  const SKIP_GUIDE_BOOK_KEY = 'skipGuideBook';
+  const { open } = useModals();
+
+  const openGuideBook = () => {
+    open(
+      ({ isOpen, onClose }) => (
+        <GuideBook
+          isOpen={isOpen}
+          onClose={() => {
+            localStorage.setItem(SKIP_GUIDE_BOOK_KEY, 'true');
+            onClose();
+          }}
+        />
+      ),
+      {
+        modalId: 'guideBook',
+      },
+    );
+  };
+
+  useEffect(() => {
+    if (!localStorage.getItem(SKIP_GUIDE_BOOK_KEY)) {
+      openGuideBook();
+    }
+  }, []);
+
+  return {
+    openGuideBook,
+  };
+};
+
+export default useGuideBook;

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -55,8 +55,6 @@ const ResumeDetail = () => {
 
   const { data: resumeDetail } = useResumeDetail({ resumeId: Number(resumeId), jwt });
 
-  const PDF_BUTTON_ICON_SIZE = 24;
-
   const { totalPages, currentPageNum, scale, setTotalPages, zoomIn, zoomOut, prevPage, nextPage } = usePdf({
     initScale: isMobile ? 0.6 : 1,
   });
@@ -177,20 +175,12 @@ const ResumeDetail = () => {
             <PdfViewer.PdfPagesInfo>
               current: {currentPageNum} / {totalPages}
             </PdfViewer.PdfPagesInfo>
-            <ButtonGroup height="2rem">
-              <ButtonGroup.Button aria-label="이전 페이지로 이동" onClick={prevPage}>
-                <Icon iconName="leftArrow" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
-              </ButtonGroup.Button>
-              <ButtonGroup.Button aria-label="pdf 확대" onClick={zoomIn}>
-                <Icon iconName="plus" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
-              </ButtonGroup.Button>
-              <ButtonGroup.Button aria-label="pdf 축소" onClick={zoomOut}>
-                <Icon iconName="minus" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
-              </ButtonGroup.Button>
-              <ButtonGroup.Button aria-label="다음 페이지로 이동" onClick={nextPage}>
-                <Icon iconName="rightArrow" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
-              </ButtonGroup.Button>
-            </ButtonGroup>
+            <PdfController
+              onGoToPrevPage={prevPage}
+              onGoToNextPage={nextPage}
+              onZoomIn={zoomIn}
+              onZoomOut={zoomOut}
+            />
           </PdfViewer>
         </ResumeViewer>
 
@@ -346,3 +336,34 @@ const ResumeDetail = () => {
 };
 
 export default ResumeDetail;
+
+const PdfController = ({
+  onGoToPrevPage,
+  onGoToNextPage,
+  onZoomIn,
+  onZoomOut,
+}: {
+  onGoToPrevPage: () => void;
+  onGoToNextPage: () => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+}) => {
+  const PDF_BUTTON_ICON_SIZE = 24;
+
+  return (
+    <ButtonGroup height="2rem">
+      <ButtonGroup.Button aria-label="이전 페이지로 이동" onClick={onGoToPrevPage}>
+        <Icon iconName="leftArrow" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
+      </ButtonGroup.Button>
+      <ButtonGroup.Button aria-label="pdf 확대" onClick={onZoomIn}>
+        <Icon iconName="plus" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
+      </ButtonGroup.Button>
+      <ButtonGroup.Button aria-label="pdf 축소" onClick={onZoomOut}>
+        <Icon iconName="minus" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
+      </ButtonGroup.Button>
+      <ButtonGroup.Button aria-label="다음 페이지로 이동" onClick={onGoToNextPage}>
+        <Icon iconName="rightArrow" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
+      </ButtonGroup.Button>
+    </ButtonGroup>
+  );
+};

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -1,14 +1,16 @@
-import React, { MouseEvent, useRef, useState } from 'react';
+import React, { MouseEvent, Suspense, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Icon, Switch, theme } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
 import CommentAddForm from '@components/CommentForm/CommentAddForm';
+import DelayedComponent from '@components/DelayedComponent';
 import Feedback from '@components/Feedback';
 import FeedbackAddForm from '@components/FeedbackForm/FeedbackAddForm';
 import PdfViewer from '@components/PdfViewer';
 import Question from '@components/Question';
 import QuestionAddForm from '@components/QuestionForm/QuestionAddForm';
+import Spinner from '@components/Spinner';
 import useGuideBook from '@hooks/useGuideBook';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useMediaQuery from '@hooks/useMediaQuery';
@@ -17,7 +19,7 @@ import { useUserContext } from '@contexts/userContext';
 import { useCommentList } from '@apis/commentApi';
 import { useFeedbackList } from '@apis/feedbackApi';
 import { useQuestionList } from '@apis/questionApi';
-import { useResumeDetail } from '@apis/resumeApi';
+import { GetResumeDetail, useResumeDetail } from '@apis/resumeApi';
 import { breakPoints } from '@styles/common';
 import { IconButton } from '@styles/iconButton';
 import { isNumeric } from '@utils';
@@ -42,6 +44,7 @@ import {
   TitleContainer,
   CommentListWrapper,
   EmptyListNotification,
+  SpinnerWrapper,
 } from './style';
 
 type ActiveTab = 'feedback' | 'question' | 'comment';
@@ -49,7 +52,6 @@ type ActiveTab = 'feedback' | 'question' | 'comment';
 const ResumeDetail = () => {
   const { jwt, user } = useUserContext();
   const { resumeId } = useParams();
-  const isValidResumeId = isNumeric(resumeId);
 
   const { matches: isMobile } = useMediaQuery({ mediaQueryString: breakPoints.mobile });
 
@@ -66,65 +68,13 @@ const ResumeDetail = () => {
     bookmarked: false,
   });
 
-  const {
-    data: feedbackList,
-    fetchNextPage: fetchNextPageAboutFeedback,
-    hasNextPage: hasNextPageAboutFeedback,
-    isFetchingNextPage: isFetchingNextPageAboutFeedback,
-  } = useFeedbackList({
-    resumeId: Number(resumeId),
-    resumePage: currentPageNum,
-    checked: filter.checked,
-    enabled: currentTab === 'feedback',
-    jwt,
-  });
-  const {
-    data: questionList,
-    fetchNextPage: fetchNextPageAboutQuestion,
-    hasNextPage: hasNextPageAboutQuestion,
-    isFetchingNextPage: isFetchingNextPageAboutQuestion,
-  } = useQuestionList({
-    resumeId: Number(resumeId),
-    resumePage: currentPageNum,
-    checked: filter.checked,
-    bookmarked: filter.bookmarked,
-    enabled: currentTab === 'question',
-    jwt,
-  });
-  const {
-    data: commentList,
-    fetchNextPage: fetchNextPageAboutComment,
-    hasNextPage: hasNextPageAboutComment,
-    isFetchingNextPage: isFetchingNextPageAboutComment,
-  } = useCommentList({
-    resumeId: Number(resumeId),
-    enabled: currentTab === 'comment',
-    jwt,
-  });
-
-  const { setTarget } = useIntersectionObserver({
-    onIntersect: () => {
-      if (currentTab === 'feedback') fetchNextPageAboutFeedback();
-      else if (currentTab === 'question') fetchNextPageAboutQuestion();
-      else if (currentTab === 'comment') fetchNextPageAboutComment();
-    },
-    options: {
-      threshold: 0.5,
-    },
-  });
-
   const handleTabClick = (e: MouseEvent<HTMLButtonElement>, tab: ActiveTab) => {
     setCurrentTab(tab);
     setFilter({ checked: false, bookmarked: false });
   };
 
-  const commentListRef = useRef<HTMLUListElement>(null);
-
-  const scrollToTopOfCommentList = () => {
-    commentListRef.current?.scrollIntoView({ behavior: 'smooth' });
-  };
-
   const isMyResume = resumeDetail.writerId === user?.id;
+  const isValidResumeId = isNumeric(resumeId);
 
   const { openGuideBook } = useGuideBook();
 
@@ -193,131 +143,57 @@ const ResumeDetail = () => {
           </AsideHeader>
 
           {currentTab === 'feedback' && isValidResumeId && (
-            <>
-              <CommentListWrapper>
-                <CommentList ref={commentListRef}>
-                  <CommentHeader>
-                    <span>필터</span>
-                    <Switch
-                      label="check"
-                      checked={filter.checked}
-                      onChange={() => {
-                        setFilter((prev) => ({ ...prev, checked: !prev.checked }));
-                      }}
-                    />
-                  </CommentHeader>
-
-                  {feedbackList && feedbackList.length > 0 ? (
-                    feedbackList.map((feedback) => {
-                      return (
-                        <li key={feedback.id}>
-                          <Feedback
-                            resumeId={Number(resumeId)}
-                            resumePage={currentPageNum}
-                            resumeWriterId={resumeDetail.writerId}
-                            {...feedback}
-                          />
-                        </li>
-                      );
-                    })
-                  ) : (
-                    <EmptyListNotification>
-                      <span>아직 작성된 피드백이 없어요.</span>
-                      <span>피드백을 남겨보세요!</span>
-                    </EmptyListNotification>
-                  )}
-                  {hasNextPageAboutFeedback && !isFetchingNextPageAboutFeedback && (
-                    <div ref={setTarget}></div>
-                  )}
-                </CommentList>
-              </CommentListWrapper>
-              <FeedbackAddForm
+            <Suspense
+              fallback={
+                <DelayedComponent>
+                  <SpinnerWrapper>
+                    <Spinner size="5rem" />
+                  </SpinnerWrapper>
+                </DelayedComponent>
+              }
+            >
+              <FeedbackSection
+                resumeDetail={resumeDetail}
                 resumeId={Number(resumeId)}
-                resumePage={currentPageNum}
-                onSubmitSuccess={scrollToTopOfCommentList}
+                currentPageNum={currentPageNum}
+                filter={filter}
+                onChangeFilter={setFilter}
               />
-            </>
+            </Suspense>
           )}
 
           {currentTab === 'question' && isValidResumeId && (
-            <>
-              <CommentListWrapper>
-                <CommentList ref={commentListRef}>
-                  <CommentHeader>
-                    <span>필터</span>
-                    <SwitchContainer>
-                      <Switch
-                        label="check"
-                        checked={filter.checked}
-                        onChange={() => {
-                          setFilter((prev) => ({ ...prev, checked: !prev.checked }));
-                        }}
-                      />
-                      <Switch
-                        label="bookmark"
-                        checked={filter.bookmarked}
-                        onChange={() => {
-                          setFilter((prev) => ({ ...prev, bookmarked: !prev.bookmarked }));
-                        }}
-                      />
-                    </SwitchContainer>
-                  </CommentHeader>
-
-                  {questionList && questionList.length > 0 ? (
-                    questionList.map((question) => {
-                      return (
-                        <li key={question.id}>
-                          <Question
-                            resumeId={Number(resumeId)}
-                            resumePage={currentPageNum}
-                            resumeWriterId={resumeDetail.writerId}
-                            {...question}
-                          />
-                        </li>
-                      );
-                    })
-                  ) : (
-                    <EmptyListNotification>
-                      <span>아직 작성된 예상질문이 없어요.</span>
-                      <span>예상질문을 남겨보세요!</span>
-                    </EmptyListNotification>
-                  )}
-                  {hasNextPageAboutQuestion && !isFetchingNextPageAboutQuestion && (
-                    <div ref={setTarget}></div>
-                  )}
-                </CommentList>
-              </CommentListWrapper>
-              <QuestionAddForm
+            <Suspense
+              fallback={
+                <DelayedComponent>
+                  <SpinnerWrapper>
+                    <Spinner size="5rem" />
+                  </SpinnerWrapper>
+                </DelayedComponent>
+              }
+            >
+              <QuestionSection
+                resumeDetail={resumeDetail}
                 resumeId={Number(resumeId)}
-                resumePage={currentPageNum}
-                onSubmitSuccess={scrollToTopOfCommentList}
+                currentPageNum={currentPageNum}
+                filter={filter}
+                onChangeFilter={setFilter}
               />
-            </>
+            </Suspense>
           )}
 
           {currentTab === 'comment' && isValidResumeId && (
-            <>
-              <CommentListWrapper>
-                <CommentList ref={commentListRef}>
-                  {commentList && commentList.length > 0 ? (
-                    commentList.map((comment) => {
-                      return (
-                        <li key={comment.id}>
-                          <Comment resumeId={Number(resumeId)} {...comment} />
-                        </li>
-                      );
-                    })
-                  ) : (
-                    <EmptyListNotification>
-                      <span>아직 댓글이 없어요.</span>
-                      <span>댓글을 남겨보세요!</span>
-                    </EmptyListNotification>
-                  )}
-                  {hasNextPageAboutComment && !isFetchingNextPageAboutComment && <div ref={setTarget}></div>}
-                </CommentList>
-              </CommentListWrapper>
-              <CommentAddForm resumeId={Number(resumeId)} onSubmitSuccess={scrollToTopOfCommentList} />
-            </>
+            <Suspense
+              fallback={
+                <DelayedComponent>
+                  <SpinnerWrapper>
+                    <Spinner size="5rem" />
+                  </SpinnerWrapper>
+                </DelayedComponent>
+              }
+            >
+              <CommentSection resumeId={Number(resumeId)} />
+            </Suspense>
           )}
         </Aside>
       </ResumeContentWrapper>
@@ -369,5 +245,230 @@ const PdfController = ({
         <Icon iconName="rightArrow" width={PDF_BUTTON_ICON_SIZE} height={PDF_BUTTON_ICON_SIZE} />
       </ButtonGroup.Button>
     </ButtonGroup>
+  );
+};
+
+const FeedbackSection = ({
+  resumeDetail,
+  resumeId,
+  currentPageNum,
+  onChangeFilter,
+  filter,
+}: {
+  resumeDetail: GetResumeDetail;
+  resumeId: number;
+  currentPageNum: number;
+  onChangeFilter: (filter: { checked: boolean; bookmarked: boolean }) => void;
+  filter: { checked: boolean; bookmarked: boolean };
+}) => {
+  const { jwt } = useUserContext();
+  const {
+    data: feedbackList,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useFeedbackList({
+    resumeId,
+    resumePage: currentPageNum,
+    checked: filter.checked,
+    jwt,
+  });
+  const { setTarget } = useIntersectionObserver({
+    onIntersect: () => {
+      fetchNextPage();
+    },
+    options: {
+      threshold: 0.5,
+    },
+  });
+
+  const feedbackListRef = useRef<HTMLUListElement>(null);
+
+  const scrollToTop = () => {
+    feedbackListRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <>
+      <CommentListWrapper>
+        <CommentList ref={feedbackListRef}>
+          <CommentHeader>
+            <span>필터</span>
+            <Switch
+              label="check"
+              checked={filter.checked}
+              onChange={() => {
+                onChangeFilter({ ...filter, checked: !filter.checked });
+              }}
+            />
+          </CommentHeader>
+
+          {feedbackList && feedbackList.length > 0 ? (
+            feedbackList.map((feedback) => {
+              return (
+                <li key={feedback.id}>
+                  <Feedback
+                    resumeId={resumeId}
+                    resumePage={currentPageNum}
+                    resumeWriterId={resumeDetail.writerId}
+                    {...feedback}
+                  />
+                </li>
+              );
+            })
+          ) : (
+            <EmptyListNotification>
+              <span>아직 작성된 피드백이 없어요.</span>
+              <span>피드백을 남겨보세요!</span>
+            </EmptyListNotification>
+          )}
+          {hasNextPage && !isFetchingNextPage && <div ref={setTarget}></div>}
+        </CommentList>
+      </CommentListWrapper>
+      <FeedbackAddForm resumeId={resumeId} resumePage={currentPageNum} onSubmitSuccess={scrollToTop} />
+    </>
+  );
+};
+
+const QuestionSection = ({
+  resumeDetail,
+  resumeId,
+  currentPageNum,
+  filter,
+  onChangeFilter,
+}: {
+  resumeDetail: GetResumeDetail;
+  resumeId: number;
+  currentPageNum: number;
+  onChangeFilter: (filter: { checked: boolean; bookmarked: boolean }) => void;
+  filter: { checked: boolean; bookmarked: boolean };
+}) => {
+  const { jwt } = useUserContext();
+  const {
+    data: questionList,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useQuestionList({
+    resumeId,
+    resumePage: currentPageNum,
+    checked: filter.checked,
+    bookmarked: filter.bookmarked,
+    jwt,
+  });
+  const { setTarget } = useIntersectionObserver({
+    onIntersect: () => {
+      fetchNextPage();
+    },
+    options: {
+      threshold: 0.5,
+    },
+  });
+
+  const questionListRef = useRef<HTMLUListElement>(null);
+
+  const scrollToTop = () => {
+    questionListRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+  return (
+    <>
+      <CommentListWrapper>
+        <CommentList ref={questionListRef}>
+          <CommentHeader>
+            <span>필터</span>
+            <SwitchContainer>
+              <Switch
+                label="check"
+                checked={filter.checked}
+                onChange={() => {
+                  onChangeFilter({ ...filter, checked: !filter.checked });
+                }}
+              />
+              <Switch
+                label="bookmark"
+                checked={filter.bookmarked}
+                onChange={() => {
+                  onChangeFilter({ ...filter, bookmarked: !filter.bookmarked });
+                }}
+              />
+            </SwitchContainer>
+          </CommentHeader>
+
+          {questionList && questionList.length > 0 ? (
+            questionList.map((question) => {
+              return (
+                <li key={question.id}>
+                  <Question
+                    resumeId={Number(resumeId)}
+                    resumePage={currentPageNum}
+                    resumeWriterId={resumeDetail.writerId}
+                    {...question}
+                  />
+                </li>
+              );
+            })
+          ) : (
+            <EmptyListNotification>
+              <span>아직 작성된 예상질문이 없어요.</span>
+              <span>예상질문을 남겨보세요!</span>
+            </EmptyListNotification>
+          )}
+          {hasNextPage && !isFetchingNextPage && <div ref={setTarget}></div>}
+        </CommentList>
+      </CommentListWrapper>
+      <QuestionAddForm resumeId={resumeId} resumePage={currentPageNum} onSubmitSuccess={scrollToTop} />
+    </>
+  );
+};
+
+const CommentSection = ({ resumeId }: { resumeId: number }) => {
+  const { jwt } = useUserContext();
+  const {
+    data: commentList,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useCommentList({
+    resumeId,
+    jwt,
+  });
+  const { setTarget } = useIntersectionObserver({
+    onIntersect: () => {
+      fetchNextPage();
+    },
+    options: {
+      threshold: 0.5,
+    },
+  });
+
+  const commentListRef = useRef<HTMLUListElement>(null);
+
+  const scrollToTop = () => {
+    commentListRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <>
+      <CommentListWrapper>
+        <CommentList ref={commentListRef}>
+          {commentList && commentList.length > 0 ? (
+            commentList.map((comment) => {
+              return (
+                <li key={comment.id}>
+                  <Comment resumeId={resumeId} {...comment} />
+                </li>
+              );
+            })
+          ) : (
+            <EmptyListNotification>
+              <span>아직 댓글이 없어요.</span>
+              <span>댓글을 남겨보세요!</span>
+            </EmptyListNotification>
+          )}
+          {hasNextPage && !isFetchingNextPage && <div ref={setTarget}></div>}
+        </CommentList>
+      </CommentListWrapper>
+      <CommentAddForm resumeId={resumeId} onSubmitSuccess={scrollToTop} />
+    </>
   );
 };

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEvent, Suspense, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { usePrefetchQuery } from '@tanstack/react-query';
 import { Icon, Switch, theme } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
 import Comment from '@components/Comment';
@@ -20,6 +21,7 @@ import { useCommentList } from '@apis/commentApi';
 import { useFeedbackList } from '@apis/feedbackApi';
 import { useQuestionList } from '@apis/questionApi';
 import { GetResumeDetail, useResumeDetail } from '@apis/resumeApi';
+import { getEmojiList, getFeedbackLabelList } from '@apis/utilApi';
 import { breakPoints } from '@styles/common';
 import { IconButton } from '@styles/iconButton';
 import { isNumeric } from '@utils';
@@ -54,6 +56,15 @@ const ResumeDetail = () => {
   const { resumeId } = useParams();
 
   const { matches: isMobile } = useMediaQuery({ mediaQueryString: breakPoints.mobile });
+
+  usePrefetchQuery({
+    queryKey: ['emojiList'],
+    queryFn: getEmojiList,
+  });
+  usePrefetchQuery({
+    queryKey: ['feedbackLabelList'],
+    queryFn: getFeedbackLabelList,
+  });
 
   const { data: resumeDetail } = useResumeDetail({ resumeId: Number(resumeId), jwt });
 

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useEffect, useRef, useState } from 'react';
+import React, { MouseEvent, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Icon, Switch, theme } from 'review-me-design-system';
 import ButtonGroup from '@components/ButtonGroup';
@@ -6,13 +6,12 @@ import Comment from '@components/Comment';
 import CommentAddForm from '@components/CommentForm/CommentAddForm';
 import Feedback from '@components/Feedback';
 import FeedbackAddForm from '@components/FeedbackForm/FeedbackAddForm';
-import GuideBook from '@components/Modal/GuideBook';
 import PdfViewer from '@components/PdfViewer';
 import Question from '@components/Question';
 import QuestionAddForm from '@components/QuestionForm/QuestionAddForm';
+import useGuideBook from '@hooks/useGuideBook';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useMediaQuery from '@hooks/useMediaQuery';
-import useModals from '@hooks/useModals';
 import usePdf from '@hooks/usePdf';
 import { useUserContext } from '@contexts/userContext';
 import { useCommentList } from '@apis/commentApi';
@@ -121,8 +120,6 @@ const ResumeDetail = () => {
     setFilter({ checked: false, bookmarked: false });
   };
 
-  const { open } = useModals();
-
   const commentListRef = useRef<HTMLUListElement>(null);
 
   const scrollToTopOfCommentList = () => {
@@ -131,26 +128,7 @@ const ResumeDetail = () => {
 
   const isMyResume = resumeDetail.writerId === user?.id;
 
-  const SKIP_GUIDE_BOOK_KEY = 'skipGuideBook';
-
-  useEffect(() => {
-    if (!localStorage.getItem(SKIP_GUIDE_BOOK_KEY)) {
-      open(
-        ({ isOpen, onClose }) => (
-          <GuideBook
-            isOpen={isOpen}
-            onClose={() => {
-              localStorage.setItem(SKIP_GUIDE_BOOK_KEY, 'true');
-              onClose();
-            }}
-          />
-        ),
-        {
-          modalId: 'guideBook',
-        },
-      );
-    }
-  }, []);
+  const { openGuideBook } = useGuideBook();
 
   return (
     <Main>
@@ -229,20 +207,7 @@ const ResumeDetail = () => {
                 댓글
               </Tab>
             </TabList>
-            <IconButton
-              aria-label="가이드북 열기"
-              onClick={() => {
-                open(({ isOpen, onClose }) => (
-                  <GuideBook
-                    isOpen={isOpen}
-                    onClose={() => {
-                      localStorage.setItem(SKIP_GUIDE_BOOK_KEY, 'true');
-                      onClose();
-                    }}
-                  />
-                ));
-              }}
-            >
+            <IconButton aria-label="가이드북 열기" onClick={openGuideBook}>
               <Icon iconName="info" color={theme.palette.blue} width={24} height={24} />
             </IconButton>
           </AsideHeader>

--- a/src/pages/ResumeDetail/index.tsx
+++ b/src/pages/ResumeDetail/index.tsx
@@ -135,17 +135,7 @@ const ResumeDetail = () => {
           <ResumeViewerHeader>
             <ResumeInfo>
               <TitleContainer>
-                {isMyResume && (
-                  <a
-                    href={`${process.env.BASE_PDF_URL}/${resumeDetail.resumeUrl}`}
-                    download={resumeDetail.title}
-                    target="_blank"
-                    rel="noreferrer"
-                    style={{ display: 'flex' }}
-                  >
-                    <Icon iconName="download" color={theme.color.accent.bd.weak} />
-                  </a>
-                )}
+                {isMyResume && <PdfLink resumeUrl={resumeDetail.resumeUrl} title={resumeDetail.title} />}
                 <Title>{resumeDetail.title}</Title>
               </TitleContainer>
 
@@ -336,6 +326,20 @@ const ResumeDetail = () => {
 };
 
 export default ResumeDetail;
+
+const PdfLink = ({ resumeUrl, title }: { resumeUrl: string; title: string }) => {
+  return (
+    <a
+      href={`${process.env.BASE_PDF_URL}/${resumeUrl}`}
+      download={title}
+      target="_blank"
+      rel="noreferrer"
+      style={{ display: 'flex' }}
+    >
+      <Icon iconName="download" color={theme.color.accent.bd.weak} />
+    </a>
+  );
+};
 
 const PdfController = ({
   onGoToPrevPage,

--- a/src/pages/ResumeDetail/style.ts
+++ b/src/pages/ResumeDetail/style.ts
@@ -190,6 +190,13 @@ const EmptyListNotification = styled.div`
   color: ${theme.palette.gray600};
 `;
 
+const SpinnerWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+
 export {
   Main,
   ResumeViewer,
@@ -211,4 +218,5 @@ export {
   CommentHeader,
   SwitchContainer,
   EmptyListNotification,
+  SpinnerWrapper,
 };


### PR DESCRIPTION
## 개요

피드백, 예상질문, 댓글 탭이 있고 어떤 탭이 활성화 되느냐에 따라 보여주는 UI도 다르다. 동시에 실행되지 않는 로직이 하나의 컴포넌트에 모여서 내부 로직이 복잡했었다. 이를 개선하기 위해 피드백, 예상질문, 댓글 각 section 컴포넌트를 만들었다.

## 작업 사항

- 피드백, 예상질문, 댓글 각 section 컴포넌트 생성
- 피드백, 예상질문, 댓글 목록을 불러오는 쿼리를 useInfiniteQuery에서 useSuspenseInfiniteQuery로 변경
- 가이드북 로직을 커스텀훅으로 분리
- tanstack query 버전 업그레이드
- 이미지 목록과 피드백 라벨 목록 쿼리 prefetch

