### PR TITLE
[FE] file-loader 삭제

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "eslint-plugin-jest": "^28.5.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "file-loader": "^6.2.0",
         "fork-ts-checker-webpack-plugin": "^9.0.2",
         "html-webpack-plugin": "^5.5.3",
         "jest": "^29.7.0",
@@ -12923,26 +12922,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/file-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/file-system-cache": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint-plugin-jest": "^28.5.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "^9.0.2",
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.7.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -49,15 +49,7 @@ module.exports = {
       },
       {
         test: /\.(mp4|png|jpg|webp)$/i,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]',
-              outputPath: 'assets',
-            },
-          },
-        ],
+        type: 'asset/resource',
       },
     ],
   },


### PR DESCRIPTION
## 개요

webpack5에서 [file-loader가 DEPRECATED](https://v4.webpack.js.org/loaders/file-loader/)다. 
그래서, [asset module](https://webpack.js.org/guides/asset-modules/)로 다시 설정했다.

## 작업 사항

## 이슈 번호
